### PR TITLE
Sqlite table create script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.1.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A minimal Electron application for SQL Databases",
   "browserslist": {
     "production": [

--- a/src/components/TableActions/index.tsx
+++ b/src/components/TableActions/index.tsx
@@ -262,9 +262,20 @@ function getCreateTable(input: TableActionInput): TableActionOutput | undefined 
         query: `CREATE TABLE ${input.tableId} (${columnString})`,
       };
     case 'sqlite':
+      columnString = input.columns
+        .map((col) =>
+          [
+            col.name,
+            col.type,
+            col.primaryKey ? 'PRIMARY KEY' : '',
+            col.autoIncrement ? 'AUTOINCREMENT' : '',
+            col.allowNull ? '' : 'NOT NULL',
+          ].join(' '),
+        )
+        .join(',\n');
       return {
         label,
-        query: `CREATE TABLE`,
+        query: `CREATE TABLE ${input.tableId} (${columnString})`,
       };
     case 'mariadb':
     case 'mysql':
@@ -319,7 +330,7 @@ function getAddColumn(input: TableActionInput): TableActionOutput | undefined {
     case 'sqlite':
       return {
         label,
-        query: `ALTER TABLE ${input.tableId} ADD COLUMN colname${Date.now()} varchar(200)`,
+        query: `ALTER TABLE ${input.tableId} ADD COLUMN colname${Date.now()} TEXT`,
       };
     case 'mariadb':
     case 'mysql':


### PR DESCRIPTION
Support create table definition for sqlite

![image](https://user-images.githubusercontent.com/3792401/151816116-9d216659-f58f-4ed7-a8e9-29d09d253a3d.png)


Sample create script
```
CREATE TABLE contacts (
  contact_id INTEGER PRIMARY KEY,
  first_name TEXT NOT NULL,
  last_name TEXT NOT NULL,
  email TEXT NOT NULL,
  phone TEXT NOT NULL
)
```