### PR TITLE
Use styled component for textarea used in code and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Also these sessions, and the associated connections and queries are persisted lo
 Dark mode will be turned on automatically with respect to your OS Preference.
 ![demo-darkmode](https://user-images.githubusercontent.com/3792401/151746840-e4889ae1-cab9-4ade-b56b-5a4dbb654712.gif)
 
+
+### Query Tabs
+When there is more than 20 tabs, the query tabs will be wrapped vertically.
+![image](https://user-images.githubusercontent.com/3792401/152028900-400605a2-0cb0-48df-9249-8ce060d3a256.png)
+
+### Command Palette
+Similar to VS Code and Sublime Text, sqlui-native comes with a command palette that lets you reach your mostly used command via a key combo `CMD + P` or `Ctrl + P` on Windows.
+![image](https://user-images.githubusercontent.com/3792401/152029205-5798c53d-6304-40dc-b9d8-11700bfc03f2.png)
+
 ## Contributing
 - [Repo](https://github.com/synle/sqlui-native)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A minimal Electron application for SQL Databases",
   "browserslist": {
     "production": [

--- a/src/App.scss
+++ b/src/App.scss
@@ -132,14 +132,6 @@
   }
 }
 
-.CodeEditorBox {
-  &:hover,
-  &:focus {
-    border: 2px solid #aaa !important;
-    outline: none;
-  }
-}
-
 .DropdownButton {
   &__Popper {
     padding: 10px 15px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -83,29 +83,6 @@
   }
 }
 
-.Accordion {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  min-height: 37px;
-
-  * {
-    margin-right: 5px;
-  }
-
-  *:last-child {
-    margin-right: 0;
-  }
-
-  > span {
-    flex-grow: 1;
-    font-weight: bold;
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-}
-
 .Tabs {
   &__Vertical {
     display: flex;

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -3,7 +3,39 @@ import Typography from '@mui/material/Typography';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Box from '@mui/material/Box';
-import { blue } from '@mui/material/colors';
+import { styled, createTheme, ThemeProvider } from '@mui/system';
+
+const StyledAccordionHeader = styled('div')(({ theme }) => {
+  const backgroundColor = theme.palette.grey[800];
+
+  return {
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '37px',
+
+    '&:hover, &:focus': {
+      backgroundColor,
+      color: theme.palette.getContrastText(backgroundColor),
+    },
+
+    '*': {
+      marginRight: '5px',
+    },
+
+    '*:last-child': {
+      marginRight: 0,
+    },
+
+    '> span': {
+      flexGrow: '1',
+      fontWeight: 'bold',
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+  };
+});
 
 type AccordionBodyProps = {
   children: React.ReactNode[] | React.ReactNode;
@@ -17,17 +49,14 @@ type AccordionHeaderProps = AccordionBodyProps & {
 export function AccordionHeader(props: AccordionHeaderProps) {
   const { children, expanded, onToggle } = props;
   return (
-    <Box
-      onClick={() => onToggle()}
-      className='Accordion'
-      sx={{
-        '&:hover': {
-          background: blue[600],
-        },
-      }}>
-      {!expanded ? <ExpandLessIcon fontSize='inherit' /> : <ExpandMoreIcon fontSize='inherit' />}
+    <StyledAccordionHeader onClick={() => onToggle()} className='Accordion'>
+      {!expanded ? (
+        <ExpandLessIcon fontSize='inherit' color='inherit' />
+      ) : (
+        <ExpandMoreIcon fontSize='inherit' color='inherit' />
+      )}
       {children}
-    </Box>
+    </StyledAccordionHeader>
   );
 }
 

--- a/src/components/CodeEditorBox/SchemaEditor.tsx
+++ b/src/components/CodeEditorBox/SchemaEditor.tsx
@@ -1,5 +1,26 @@
 // @ts-nocheck
 import { useState, useEffect, useCallback } from 'react';
+import { styled, createTheme, ThemeProvider } from '@mui/system';
+import { grey } from '@mui/material/colors';
+
+const StyledTextArea = styled('textarea')(({ theme }) => {
+  const backgroundColor = grey[800];
+  return {
+    backgroundColor,
+    color: theme.palette.getContrastText(backgroundColor),
+    border: '2px solid transparent',
+    fontFamily: 'monospace',
+    fontWeight: '700',
+    width: '100%',
+    minHeight: '200px',
+    padding: '10px',
+    resize: 'vertical',
+    outline: 'none',
+    '&:hover, &:focus': {
+      borderColor: theme.palette.primary.main,
+    },
+  };
+});
 
 export default function SchemaEditor(props) {
   const onInputKeyDown = useCallback((e) => {
@@ -140,5 +161,5 @@ export default function SchemaEditor(props) {
     }
   }, []);
 
-  return <textarea onKeyDown={(e) => onInputKeyDown(e)} {...props}></textarea>;
+  return <StyledTextArea onKeyDown={(e) => onInputKeyDown(e)} {...props} />;
 }

--- a/src/components/CodeEditorBox/index.tsx
+++ b/src/components/CodeEditorBox/index.tsx
@@ -43,15 +43,6 @@ export default function CodeEditorBox(props: CodeEditorProps) {
         autoFocus={props.autoFocus}
         required={props.required}
         style={{
-          backgroundColor: grey[800],
-          border: '2px solid transparent',
-          fontFamily: 'monospace',
-          fontWeight: '700',
-          width: '100%',
-          minHeight: '200px',
-          color: grey[50],
-          padding: '10px',
-          resize: 'vertical',
           whiteSpace: wordWrap ? 'initial' : 'nowrap',
         }}
       />

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -28,8 +28,9 @@ const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
   { event: 'clientEvent/connection/new', label: 'New Connection' },
   { event: 'clientEvent/query/new', label: 'New Query' },
   { event: 'clientEvent/query/show', label: 'Show Query', expandQueries: true },
-  { event: 'clientEvent/query/showNext', label: 'Show Next Query', useCurrentQuery: true },
-  { event: 'clientEvent/query/showPrev', label: 'Show Prev Query', useCurrentQuery: true },
+  // these 2 commands don't make sense, let's disable it...
+  // { event: 'clientEvent/query/showNext', label: 'Show Next Query', useCurrentQuery: true },
+  // { event: 'clientEvent/query/showPrev', label: 'Show Prev Query', useCurrentQuery: true },
   { event: 'clientEvent/query/rename', label: 'Rename Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/export', label: 'Export Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/duplicate', label: 'Duplicate Current Query', useCurrentQuery: true },

--- a/src/components/ConnectionDescription/index.tsx
+++ b/src/components/ConnectionDescription/index.tsx
@@ -237,8 +237,8 @@ function ConnectionActions(props: ConnectionActionsProps) {
   return (
     <>
       <DropdownButton id='connection-actions-split-button' options={options}>
-        <IconButton aria-label='Connection Actions' size='small'>
-          <ArrowDropDownIcon fontSize='inherit' />
+        <IconButton aria-label='Connection Actions' size='small' color='inherit'>
+          <ArrowDropDownIcon fontSize='inherit' color='inherit' />
         </IconButton>
       </DropdownButton>
       <Toast open={!!message} onClose={() => setMessage('')} message={message} />

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -21,33 +21,26 @@ interface DataTableProps {
   data: any[];
 }
 
-const pageSizeOptions : any[] = [10, 25, 50, 100, {label: 'Show All', value: -1}]
+const pageSizeOptions: any[] = [10, 25, 50, 100, { label: 'Show All', value: -1 }];
 
 export default function DataTable(props: DataTableProps) {
   const { columns, data } = props;
 
   //@ts-ignore
-  const {
-    getTableBodyProps,
-    gotoPage,
-    headerGroups,
-    page,
-    prepareRow,
-    setPageSize,
-    state,
-  } = useTable(
-    {
-      initialState: {
-        pageSize: 50,
+  const { getTableBodyProps, gotoPage, headerGroups, page, prepareRow, setPageSize, state } =
+    useTable(
+      {
+        initialState: {
+          pageSize: 50,
+        },
+        columns,
+        data,
       },
-      columns,
-      data,
-    },
-    useFilters,
-    useGlobalFilter,
-    useSortBy,
-    usePagination,
-  );
+      useFilters,
+      useGlobalFilter,
+      useSortBy,
+      usePagination,
+    );
   const { pageIndex, pageSize } = state;
 
   const onPageChange = useCallback(

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -73,7 +73,7 @@ export default function DataTable(props: DataTableProps) {
               return (
                 <TableRow {...row.getRowProps()}>
                   {row.cells.map((cell) => {
-                    return <TableCell>{cell.render('Cell')}</TableCell>;
+                    return <TableCell {...cell.getCellProps()}>{cell.render('Cell')}</TableCell>;
                   })}
                 </TableRow>
               );

--- a/src/components/DatabaseDescription/index.tsx
+++ b/src/components/DatabaseDescription/index.tsx
@@ -60,7 +60,8 @@ export default function DatabaseDescription(props: DatabaseDescriptionProps) {
                 <IconButton
                   aria-label='Select Database For Execution'
                   onClick={(e) => onSelectDatabaseForQuery(e, database.name)}
-                  size='small'>
+                  size='small'
+                  color='inherit'>
                   <SelectAllIcon fontSize='inherit' />
                 </IconButton>
               </Tooltip>

--- a/src/components/DropdownButton/index.tsx
+++ b/src/components/DropdownButton/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import Button from '@mui/material/Button';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
 import Paper from '@mui/material/Paper';

--- a/src/components/QueryBox/index.tsx
+++ b/src/components/QueryBox/index.tsx
@@ -10,6 +10,8 @@ import NativeSelect from '@mui/material/NativeSelect';
 import PreviewIcon from '@mui/icons-material/Preview';
 import FormatColorTextIcon from '@mui/icons-material/FormatColorText';
 import Tooltip from '@mui/material/Tooltip';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 import {
   useGetConnections,
   useExecute,
@@ -87,9 +89,6 @@ export default function QueryBox(props: QueryBoxProps) {
     <>
       <form className='QueryBox' onSubmit={onSubmit}>
         <div className='QueryBox__Row'>
-          <Typography variant='h6'>{query.name}</Typography>
-        </div>
-        <div className='QueryBox__Row'>
           <ConnectionDatabaseSelector value={query} onChange={onDatabaseConnectionChange} />
           <ConnectionRevealButton query={query} />
         </div>
@@ -151,37 +150,40 @@ function ConnectionDatabaseSelector(props: ConnectionDatabaseSelectorProps) {
   };
 
   const connectionOptions = connections?.map((connection) => (
-    <option value={connection.id} key={connection.id}>
+    <MenuItem value={connection.id} key={connection.id}>
       {connection.name}
-    </option>
+    </MenuItem>
   ));
 
   const databaseConnections = databases?.map((database) => (
-    <option value={database.name} key={database.name}>
+    <MenuItem value={database.name} key={database.name}>
       {database.name}
-    </option>
+    </MenuItem>
   ));
 
   if (isLoading) {
-    return null;
+    <>
+      <Select disabled size='small'></Select>
+      <Select disabled size='small' sx={{ ml: 3 }}></Select>
+    </>;
   }
 
   return (
     <>
-      <NativeSelect
+      <Select
         value={query.connectionId}
-        onChange={(e) => onConnectionChange(e.target.value)}
-        required>
-        <option value=''>Pick a connection</option>
+        onChange={(e) => onConnectionChange(e.target.value as string)}
+        required
+        size='small'>
         {connectionOptions}
-      </NativeSelect>
-      <NativeSelect
+      </Select>
+      <Select
         value={query.databaseId}
-        onChange={(e) => onDatabaseChange(e.target.value)}
+        onChange={(e) => onDatabaseChange(e.target.value as string)}
+        size='small'
         sx={{ ml: 3 }}>
-        <option value=''>Pick a database (Optional)</option>
         {databaseConnections}
-      </NativeSelect>
+      </Select>
     </>
   );
 }

--- a/src/components/TableActions/index.tsx
+++ b/src/components/TableActions/index.tsx
@@ -66,8 +66,8 @@ export default function TableActions(props: TableActionsProps) {
         options={options}
         onToggle={(newOpen) => setOpen(newOpen)}
         isLoading={isLoading}>
-        <IconButton aria-label='Table Actions' size='small'>
-          <ArrowDropDownIcon fontSize='inherit' />
+        <IconButton aria-label='Table Actions' size='small' color='inherit'>
+          <ArrowDropDownIcon fontSize='inherit' color='inherit' />
         </IconButton>
       </DropdownButton>
     </div>


### PR DESCRIPTION
- Use styled component for textarea used in code. Also now uses a getContrastColor method used to get a contrast text color instead of hardcoding it.
- Fixed an issue where the key for DataTable cell is not receiving a `key` prop.
- Cleaned backgrounds of the accordion headers using styled components
- Use Select component instead of NativeSelect for the Connection / DB to use.

![image](https://user-images.githubusercontent.com/3792401/152027757-4dfdf6fc-b64d-4aa9-8ed5-fed16122a08c.png)
