### PR TITLE
Simplify the dev script with concurrently

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -68,12 +68,9 @@ npm start
 Run this and test it in the browser
 ```
 npm install
-
-# terminal 1
-npm run start-webapp
-
-# terminal 2
-npm run start-mocked
+npm run dev
+# then open a browser with URL
+# http://localhost:3000
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start-electron": "cross-env ENV_TYPE='electron-dev' cross-env ELECTRON_DISABLE_SECURITY_WARNINGS=true electron build/main.js",
     "start-webapp": "cross-env ENV_TYPE='mocked-server' SASS_PATH='./src/styles' react-scripts start",
     "start-mocked": "npx ts-node --project tsconfig-server.json mocked-server.ts",
+    "dev": "concurrently \"npm run start-mocked\" \"npm run start-webapp\"",
     "build-binary": "cpx \"build/**/*\" . && electron-builder build --publish=never",
     "build-electron": "tsc --project tsconfig-electron.json && cpx package.json build",
     "build-react": "cross-env CI=\"\" SASS_PATH='./src/styles' react-scripts build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A minimal native Desktop Electron application for running queries against popular database engines MySQL, MariaDB, Microsoft, PostgresSQL, SQLite and Cassandra",
   "browserslist": {
     "production": [


### PR DESCRIPTION
- A single script to run dev mode now. `npm run dev`.
- No longer requires to run `npm run start-webapp` and `npm run start-mocked` separately.
