### PR TITLE
Added toggle of dark mode inside the command palette.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A minimal native Desktop Electron application for running queries against popular database engines MySQL, MariaDB, Microsoft, PostgresSQL, SQLite and Cassandra",
   "browserslist": {
     "production": [

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -30,7 +30,11 @@ const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
   { event: 'clientEvent/import', label: 'Import' },
   { event: 'clientEvent/exportAll', label: 'Export All' },
   { event: 'clientEvent/changeDarkMode', label: 'Enable Dark Mode', data: 'dark' },
-  { event: 'clientEvent/changeDarkMode', label: 'Disable Dark Mode (Use Light Mode)', data: 'light' },
+  {
+    event: 'clientEvent/changeDarkMode',
+    label: 'Disable Dark Mode (Use Light Mode)',
+    data: 'light',
+  },
   { event: 'clientEvent/changeDarkMode', label: 'Follows System Settings for Dark Mode', data: '' },
   { event: 'clientEvent/connection/new', label: 'New Connection' },
   { event: 'clientEvent/session/switch', label: 'Switch Session' },
@@ -104,9 +108,9 @@ export default function CommandPalette(props: CommandPaletteProps) {
 
   let optionsToShow = options;
 
-  if(optionsToShow.length > MAX_OPTION_TO_SHOW && text.length === 0){
+  if (optionsToShow.length > MAX_OPTION_TO_SHOW && text.length === 0) {
     // limit the initial commands
-    optionsToShow = optionsToShow.slice(0, MAX_OPTION_TO_SHOW)
+    optionsToShow = optionsToShow.slice(0, MAX_OPTION_TO_SHOW);
   }
 
   return (

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -5,6 +5,8 @@ import { SqluiCore, SqluiFrontend, SqluiEnums } from 'typings';
 import { useConnectionQueries, useConnectionQuery, useActiveConnectionQuery } from 'src/hooks';
 import { useCommands, Command } from 'src/components/MissionControl';
 
+const MAX_OPTION_TO_SHOW = 20;
+
 interface CommandPaletteProps {
   onSelectCommand: (command: Command) => void;
 }
@@ -20,13 +22,20 @@ type CommandOption = {
    * whether or not to attach current query to this command
    */
   useCurrentQuery?: boolean;
+  data?: any;
 };
 
 const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
   { event: 'clientEvent/showSettings', label: 'Settings' },
   { event: 'clientEvent/import', label: 'Import' },
   { event: 'clientEvent/exportAll', label: 'Export All' },
+  { event: 'clientEvent/changeDarkMode', label: 'Enable Dark Mode', data: 'dark' },
+  { event: 'clientEvent/changeDarkMode', label: 'Disable Dark Mode (Use Light Mode)', data: 'light' },
+  { event: 'clientEvent/changeDarkMode', label: 'Follows System Settings for Dark Mode', data: '' },
   { event: 'clientEvent/connection/new', label: 'New Connection' },
+  { event: 'clientEvent/session/switch', label: 'Switch Session' },
+  { event: 'clientEvent/session/new', label: 'New Session' },
+  { event: 'clientEvent/session/rename', label: 'Rename Current Session' },
   { event: 'clientEvent/query/new', label: 'New Query' },
   { event: 'clientEvent/query/show', label: 'Show Query', expandQueries: true },
   // these 2 commands don't make sense, let's disable it...
@@ -37,9 +46,6 @@ const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
   { event: 'clientEvent/query/duplicate', label: 'Duplicate Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/close', label: 'Close Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/closeOther', label: 'Close Other Query', useCurrentQuery: true },
-  { event: 'clientEvent/session/switch', label: 'Switch Session' },
-  { event: 'clientEvent/session/new', label: 'New Session' },
-  { event: 'clientEvent/session/rename', label: 'Rename Current Session' },
 ];
 
 export default function CommandPalette(props: CommandPaletteProps) {
@@ -96,6 +102,13 @@ export default function CommandPalette(props: CommandPaletteProps) {
     return null;
   }
 
+  let optionsToShow = options;
+
+  if(optionsToShow.length > MAX_OPTION_TO_SHOW && text.length === 0){
+    // limit the initial commands
+    optionsToShow = optionsToShow.slice(0, MAX_OPTION_TO_SHOW)
+  }
+
   return (
     <div style={{ width: '400px' }}>
       <div>
@@ -106,7 +119,7 @@ export default function CommandPalette(props: CommandPaletteProps) {
           placeholder='> Type a command here'
           fullWidth
         />
-        {options.map((option, idx) => (
+        {optionsToShow.map((option, idx) => (
           <div key={`${option.event}.${idx}`}>
             <Button onClick={() => onSelectCommand(option)} title={option.event}>
               {option.label}

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -23,6 +23,7 @@ type CommandOption = {
 };
 
 const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
+  { event: 'clientEvent/showSettings', label: 'Settings' },
   { event: 'clientEvent/import', label: 'Import' },
   { event: 'clientEvent/exportAll', label: 'Export All' },
   { event: 'clientEvent/connection/new', label: 'New Connection' },

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -425,8 +425,8 @@ export default function MissionControl() {
     });
   };
 
-  const onChangeDarkMode= (newValue: string) => {
-    if(!settings){
+  const onChangeDarkMode = (newValue: string) => {
+    if (!settings) {
       return;
     }
 
@@ -434,7 +434,7 @@ export default function MissionControl() {
     settings.darkmode = newValue;
 
     onChangeSettings(settings);
-  }
+  };
 
   // mission control commands
   async function _executeCommandPalette(command: Command) {

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -31,6 +31,7 @@ import {
   useGetCurrentSession,
   useGetConnections,
   useImportConnection,
+  useSettings,
   getExportedConnection,
   getExportedQuery,
 } from 'src/hooks';
@@ -111,6 +112,7 @@ export default function MissionControl() {
   const { mutateAsync: upsertSession } = useUpsertSession();
   const { mutateAsync: importConnection } = useImportConnection();
   const { data: connections, isLoading: loadingConnections } = useGetConnections();
+  const { settings, onChange: onChangeSettings } = useSettings();
 
   const onCloseQuery = async (query: SqluiFrontend.ConnectionQuery) => {
     try {
@@ -423,6 +425,17 @@ export default function MissionControl() {
     });
   };
 
+  const onChangeDarkMode= (newValue: string) => {
+    if(!settings){
+      return;
+    }
+
+    //@ts-ignore
+    settings.darkmode = newValue;
+
+    onChangeSettings(settings);
+  }
+
   // mission control commands
   async function _executeCommandPalette(command: Command) {
     if (command) {
@@ -439,6 +452,10 @@ export default function MissionControl() {
 
         case 'clientEvent/showSettings':
           onShowSettings();
+          break;
+
+        case 'clientEvent/changeDarkMode':
+          onChangeDarkMode(command.data as string);
           break;
 
         // overall commands

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -146,6 +146,7 @@ export module SqluiEnums {
    */
   export type ClientEventKey =
     | 'clientEvent/showSettings'
+    | 'clientEvent/changeDarkMode'
     | 'clientEvent/checkForUpdate'
     | 'clientEvent/showCommandPalette'
     | 'clientEvent/import'


### PR DESCRIPTION
- Added toggle of dark mode inside the menu bar
- Cap a maximum numbers of options to show when the command palette searchbox is empty.

![image](https://user-images.githubusercontent.com/3792401/152591458-94bcdd4a-6fb3-4da5-a6fb-4f520f2631cf.png)
