### PR TITLE
Action to collapse all connection and show reveal connection in command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "A minimal native Desktop Electron application for running queries against popular database engines MySQL, MariaDB, Microsoft, PostgresSQL, SQLite and Cassandra",
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A minimal native Desktop Electron application for running queries against popular database engines MySQL, MariaDB, Microsoft, PostgresSQL, SQLite and Cassandra",
   "browserslist": {
     "production": [

--- a/src/components/ColumnDescription/index.tsx
+++ b/src/components/ColumnDescription/index.tsx
@@ -56,7 +56,7 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
   return (
     <div className='ColumnDescription'>
       {columns
-        .filter((column, idx) => showAllColumns || idx < MAX_COLUMN_SIZE_TO_SHOW)
+        .filter((column, idx) => showAllColumns || idx <= MAX_COLUMN_SIZE_TO_SHOW)
         .map((column) => {
           const key = [connectionId, databaseId, tableId, column.name].join(' > ');
           return (

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -50,7 +50,8 @@ const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
   { event: 'clientEvent/query/export', label: 'Export Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/duplicate', label: 'Duplicate Current Query', useCurrentQuery: true },
   { event: 'clientEvent/query/close', label: 'Close Current Query', useCurrentQuery: true },
-  { event: 'clientEvent/query/closeOther', label: 'Close Other Query', useCurrentQuery: true },
+  { event: 'clientEvent/query/closeOther', label: 'Close Other Query' },
+  { event: 'clientEvent/query/reveal', label: 'Reveal Query Connection' },
 ];
 
 export default function CommandPalette(props: CommandPaletteProps) {

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -35,6 +35,7 @@ const ALL_COMMAND_PALETTE_OPTIONS: CommandOption[] = [
     label: 'Disable Dark Mode (Use Light Mode)',
     data: 'light',
   },
+  { event: 'clientEvent/clearShowHides', label: 'Collapse All Connections' },
   { event: 'clientEvent/changeDarkMode', label: 'Follows System Settings for Dark Mode', data: '' },
   { event: 'clientEvent/connection/new', label: 'New Connection' },
   { event: 'clientEvent/session/switch', label: 'Switch Session' },

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -114,7 +114,7 @@ export default function MissionControl() {
   const { mutateAsync: importConnection } = useImportConnection();
   const { data: connections, isLoading: loadingConnections } = useGetConnections();
   const { settings, onChange: onChangeSettings } = useSettings();
-  const { onClear: onClearShowHides } = useShowHide();
+  const { onClear: onClearConnectionVisibles, onToggle: onToggleConnectionVisible } = useShowHide();
 
   const onCloseQuery = async (query: SqluiFrontend.ConnectionQuery) => {
     try {
@@ -155,6 +155,25 @@ export default function MissionControl() {
       'text/json',
     );
   };
+
+  const onRevealQueryConnection = async (query: SqluiFrontend.ConnectionQuery) => {
+    const { databaseId, connectionId } = query;
+
+    if (!connectionId) {
+      return;
+    }
+
+    const branchesToReveal: string[] = [connectionId];
+
+    if (databaseId && connectionId) {
+      branchesToReveal.push([connectionId, databaseId].join(' > '));
+    }
+
+    for (const branchToReveal of branchesToReveal) {
+      // reveal
+      onToggleConnectionVisible(branchToReveal, true);
+    }
+  }
 
   const onShowQueryWithDirection = (direction: number) => {
     if (!queries || !activeQuery) {
@@ -457,7 +476,7 @@ export default function MissionControl() {
           break;
 
         case 'clientEvent/clearShowHides':
-          onClearShowHides();
+          onClearConnectionVisibles();
           break;
 
         case 'clientEvent/changeDarkMode':
@@ -526,6 +545,13 @@ export default function MissionControl() {
           // this closes the active query
           if (activeQuery) {
             onCloseQuery(activeQuery);
+          }
+          break;
+
+        case 'clientEvent/query/reveal':
+          // this reveal the current query connection
+          if (activeQuery) {
+            onRevealQueryConnection(activeQuery);
           }
           break;
 

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -173,7 +173,7 @@ export default function MissionControl() {
       // reveal
       onToggleConnectionVisible(branchToReveal, true);
     }
-  }
+  };
 
   const onShowQueryWithDirection = (direction: number) => {
     if (!queries || !activeQuery) {

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -32,6 +32,7 @@ import {
   useGetConnections,
   useImportConnection,
   useSettings,
+  useShowHide,
   getExportedConnection,
   getExportedQuery,
 } from 'src/hooks';
@@ -113,6 +114,7 @@ export default function MissionControl() {
   const { mutateAsync: importConnection } = useImportConnection();
   const { data: connections, isLoading: loadingConnections } = useGetConnections();
   const { settings, onChange: onChangeSettings } = useSettings();
+  const { onClear: onClearShowHides } = useShowHide();
 
   const onCloseQuery = async (query: SqluiFrontend.ConnectionQuery) => {
     try {
@@ -452,6 +454,10 @@ export default function MissionControl() {
 
         case 'clientEvent/showSettings':
           onShowSettings();
+          break;
+
+        case 'clientEvent/clearShowHides':
+          onClearShowHides();
           break;
 
         case 'clientEvent/changeDarkMode':

--- a/src/components/NewConnectionButton/index.tsx
+++ b/src/components/NewConnectionButton/index.tsx
@@ -39,8 +39,6 @@ export default function NewConnectionButton() {
     },
   ];
 
-
-
   return (
     <Box sx={{ textAlign: 'center', marginBottom: 2, marginTop: 1 }}>
       <SplitButton

--- a/src/components/NewConnectionButton/index.tsx
+++ b/src/components/NewConnectionButton/index.tsx
@@ -4,6 +4,7 @@ import { Button } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import Box from '@mui/material/Box';
 import SplitButton from 'src/components/SplitButton';
 import { useActionDialogs } from 'src/components/ActionDialogs';
@@ -20,22 +21,25 @@ import {
 export default function NewConnectionButton() {
   const { selectCommand } = useCommands();
 
-  const onImport = () => selectCommand({ event: 'clientEvent/import' });
-  const onExportAll = () => selectCommand({ event: 'clientEvent/exportAll' });
-  const onNewConnection = () => selectCommand({ event: 'clientEvent/connection/new' });
-
   const options = [
     {
       label: 'Import',
-      onClick: onImport,
+      onClick: () => selectCommand({ event: 'clientEvent/import' }),
       startIcon: <ArrowDownwardIcon />,
     },
     {
       label: 'Export All',
-      onClick: onExportAll,
+      onClick: () => selectCommand({ event: 'clientEvent/exportAll' }),
       startIcon: <ArrowUpwardIcon />,
     },
+    {
+      label: 'Collapse All Connections',
+      onClick: () => selectCommand({ event: 'clientEvent/clearShowHides' }),
+      startIcon: <UnfoldLessIcon />,
+    },
   ];
+
+
 
   return (
     <Box sx={{ textAlign: 'center', marginBottom: 2, marginTop: 1 }}>
@@ -43,7 +47,7 @@ export default function NewConnectionButton() {
         id='new-connection-split-button'
         label='Connection'
         startIcon={<AddIcon />}
-        onClick={onNewConnection}
+        onClick={() => selectCommand({ event: 'clientEvent/connection/new' })}
         options={options}
       />
     </Box>

--- a/src/components/QueryBox/index.tsx
+++ b/src/components/QueryBox/index.tsx
@@ -203,7 +203,7 @@ interface ConnectionRevealButtonProps {
   query: SqluiFrontend.ConnectionQuery;
 }
 function ConnectionRevealButton(props: ConnectionRevealButtonProps) {
-    const { query } = props;
+  const { query } = props;
   const { selectCommand } = useCommands();
 
   if (!query) {

--- a/src/components/QueryBox/index.tsx
+++ b/src/components/QueryBox/index.tsx
@@ -20,6 +20,7 @@ import {
   useGetDatabases,
   refreshAfterExecution,
 } from 'src/hooks';
+import { useCommands } from 'src/components/MissionControl';
 import CodeEditorBox from 'src/components/CodeEditorBox';
 import ResultBox from 'src/components/ResultBox';
 import Select from 'src/components/Select';
@@ -202,27 +203,8 @@ interface ConnectionRevealButtonProps {
   query: SqluiFrontend.ConnectionQuery;
 }
 function ConnectionRevealButton(props: ConnectionRevealButtonProps) {
-  const { query } = props;
-  const { onToggle } = useShowHide();
-
-  const onReveal = () => {
-    const { databaseId, connectionId } = query;
-
-    if (!connectionId) {
-      return;
-    }
-
-    const branchesToReveal: string[] = [connectionId];
-
-    if (databaseId && connectionId) {
-      branchesToReveal.push([connectionId, databaseId].join(' > '));
-    }
-
-    for (const branchToReveal of branchesToReveal) {
-      // reveal
-      onToggle(branchToReveal, true);
-    }
-  };
+    const { query } = props;
+  const { selectCommand } = useCommands();
 
   if (!query) {
     return null;
@@ -237,7 +219,7 @@ function ConnectionRevealButton(props: ConnectionRevealButtonProps) {
           type='button'
           variant='outlined'
           startIcon={<PreviewIcon />}
-          onClick={onReveal}
+          onClick={() => selectCommand({ event: 'clientEvent/query/reveal' })}
           sx={{ ml: 3 }}
           disabled={disabled}>
           Reveal

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -275,9 +275,19 @@ export function useShowHide() {
     );
   };
 
+  const onClear = () => {
+    _treeVisibles = {};
+
+    queryClient.setQueryData<SqluiFrontend.TreeVisibilities | undefined>(
+      QUERY_KEY_TREEVISIBLES,
+      () => ({ ..._treeVisibles }),
+    );
+  }
+
   return {
     visibles: visibles || {},
     onToggle,
+    onClear
   };
 }
 

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -282,12 +282,12 @@ export function useShowHide() {
       QUERY_KEY_TREEVISIBLES,
       () => ({ ..._treeVisibles }),
     );
-  }
+  };
 
   return {
     visibles: visibles || {},
     onToggle,
-    onClear
+    onClear,
   };
 }
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -149,6 +149,7 @@ export module SqluiEnums {
     | 'clientEvent/changeDarkMode'
     | 'clientEvent/checkForUpdate'
     | 'clientEvent/showCommandPalette'
+    | 'clientEvent/clearShowHides'
     | 'clientEvent/import'
     | 'clientEvent/exportAll'
     | 'clientEvent/connection/new'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -163,6 +163,7 @@ export module SqluiEnums {
     | 'clientEvent/query/close'
     | 'clientEvent/query/closeCurrentlySelected'
     | 'clientEvent/query/closeOther'
+    | 'clientEvent/query/reveal'
     | 'clientEvent/session/new'
     | 'clientEvent/session/rename'
     | 'clientEvent/session/switch';


### PR DESCRIPTION
- Action to collapse all connection 
- Show reveal connection in command palette
- Fixed an issue where `show all columns` button shouldn't be shown for column size is at exactly the max col size.
 
## Screenshots
### Collapse All Connections
![image](https://user-images.githubusercontent.com/3792401/152619297-f66afca0-52a0-49c9-b8eb-a2faa1b16f9a.png)

![image](https://user-images.githubusercontent.com/3792401/152619303-bcf14a3a-6236-42ed-be5a-d0dda9d07378.png)

![image](https://user-images.githubusercontent.com/3792401/152619312-7b276112-fa55-43f8-ad1b-eb66e0fe87d1.png)

### Reveal Connection in Command Palette
![image](https://user-images.githubusercontent.com/3792401/152619322-653897f7-4acb-4963-a15d-14365786a9b7.png)
