### PR TITLE
Consolidate code to use type instead of interfaces

### DIFF
--- a/commons/PersistentStorage.ts
+++ b/commons/PersistentStorage.ts
@@ -6,11 +6,11 @@ import { SqluiCore } from '../typings';
 const homedir = require('os').homedir();
 
 // this section of the api is caches in memory
-interface StorageContent {
+type StorageContent = {
   [index: string]: any;
 }
 
-interface StorageEntry {
+type StorageEntry = {
   id: string;
   [index: string]: any;
 }

--- a/commons/PersistentStorage.ts
+++ b/commons/PersistentStorage.ts
@@ -8,12 +8,12 @@ const homedir = require('os').homedir();
 // this section of the api is caches in memory
 type StorageContent = {
   [index: string]: any;
-}
+};
 
 type StorageEntry = {
   id: string;
   [index: string]: any;
-}
+};
 
 let baseDir: string;
 try {

--- a/src/components/ActionDialogs/AlertDialog.tsx
+++ b/src/components/ActionDialogs/AlertDialog.tsx
@@ -5,7 +5,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
-interface AlertDialogProps {
+type AlertDialogProps =  {
   open: boolean;
   title: string;
   message: string;

--- a/src/components/ActionDialogs/AlertDialog.tsx
+++ b/src/components/ActionDialogs/AlertDialog.tsx
@@ -5,7 +5,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
-type AlertDialogProps =  {
+type AlertDialogProps = {
   open: boolean;
   title: string;
   message: string;
@@ -14,7 +14,7 @@ type AlertDialogProps =  {
   noLabel?: string;
   onDismiss: () => void;
   isConfirm?: boolean;
-}
+};
 
 export default function AlertDialog(props: AlertDialogProps) {
   return (

--- a/src/components/ActionDialogs/ChoiceDialog.tsx
+++ b/src/components/ActionDialogs/ChoiceDialog.tsx
@@ -17,7 +17,7 @@ export type ChoiceInput = {
   options: ChoiceOption[];
 };
 
-interface ChoiceDialogProps {
+type ChoiceDialogProps =  {
   open: boolean;
   title: string;
   message: string | React.ReactNode;

--- a/src/components/ActionDialogs/ChoiceDialog.tsx
+++ b/src/components/ActionDialogs/ChoiceDialog.tsx
@@ -17,14 +17,14 @@ export type ChoiceInput = {
   options: ChoiceOption[];
 };
 
-type ChoiceDialogProps =  {
+type ChoiceDialogProps = {
   open: boolean;
   title: string;
   message: string | React.ReactNode;
   options: ChoiceOption[];
   onSelect: (newValue: string) => void;
   onDismiss: () => void;
-}
+};
 
 export default function ChoiceDialog(props: ChoiceDialogProps) {
   const {

--- a/src/components/ActionDialogs/index.tsx
+++ b/src/components/ActionDialogs/index.tsx
@@ -4,7 +4,7 @@ import ChoiceDialog from 'src/components/ActionDialogs/ChoiceDialog';
 import ModalDialog from 'src/components/ActionDialogs/ModalDialog';
 import PromptDialog from 'src/components/ActionDialogs/PromptDialog';
 
-type ActionDialogsProps =  {}
+type ActionDialogsProps = {};
 
 export default function ActionDialogs(props: ActionDialogsProps) {
   const { dialog, dismiss } = useActionDialogs();

--- a/src/components/ActionDialogs/index.tsx
+++ b/src/components/ActionDialogs/index.tsx
@@ -4,7 +4,7 @@ import ChoiceDialog from 'src/components/ActionDialogs/ChoiceDialog';
 import ModalDialog from 'src/components/ActionDialogs/ModalDialog';
 import PromptDialog from 'src/components/ActionDialogs/PromptDialog';
 
-interface ActionDialogsProps {}
+type ActionDialogsProps =  {}
 
 export default function ActionDialogs(props: ActionDialogsProps) {
   const { dialog, dismiss } = useActionDialogs();

--- a/src/components/CodeEditorBox/index.tsx
+++ b/src/components/CodeEditorBox/index.tsx
@@ -9,7 +9,7 @@ import { useWordWrapSetting } from 'src/hooks';
 import AdvancedEditor from 'src/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/components/CodeEditorBox/SimpleEditor';
 
-type CodeEditorProps =  {
+type CodeEditorProps = {
   value?: string;
   onChange?: (newValue: string) => void;
   language?: string;
@@ -17,7 +17,7 @@ type CodeEditorProps =  {
   mode: 'textarea' | 'code';
   autoFocus?: boolean;
   required?: boolean;
-}
+};
 
 export default function CodeEditorBox(props: CodeEditorProps) {
   const globalWordWrap = useWordWrapSetting();

--- a/src/components/CodeEditorBox/index.tsx
+++ b/src/components/CodeEditorBox/index.tsx
@@ -9,7 +9,7 @@ import { useWordWrapSetting } from 'src/hooks';
 import AdvancedEditor from 'src/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/components/CodeEditorBox/SimpleEditor';
 
-interface CodeEditorProps {
+type CodeEditorProps =  {
   value?: string;
   onChange?: (newValue: string) => void;
   language?: string;

--- a/src/components/ColumnDescription/ColumnAttributes.tsx
+++ b/src/components/ColumnDescription/ColumnAttributes.tsx
@@ -2,7 +2,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { SqluiCore } from 'typings';
 import { styled } from '@mui/system';
 
-interface ColumnAttributesProps {
+type ColumnAttributesProps =  {
   column: SqluiCore.ColumnMetaData;
 }
 

--- a/src/components/ColumnDescription/ColumnAttributes.tsx
+++ b/src/components/ColumnDescription/ColumnAttributes.tsx
@@ -2,9 +2,9 @@ import Tooltip from '@mui/material/Tooltip';
 import { SqluiCore } from 'typings';
 import { styled } from '@mui/system';
 
-type ColumnAttributesProps =  {
+type ColumnAttributesProps = {
   column: SqluiCore.ColumnMetaData;
-}
+};
 
 export default function ColumnAttributes(props: ColumnAttributesProps) {
   const { column } = props;

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -9,9 +9,9 @@ import { useConnectionQueries } from 'src/hooks';
 
 const MAX_OPTION_TO_SHOW = 20;
 
-type CommandPaletteProps =  {
+type CommandPaletteProps = {
   onSelectCommand: (command: Command) => void;
-}
+};
 
 type CommandOption = {
   event: SqluiEnums.ClientEventKey;

--- a/src/components/CommandPalette/index.tsx
+++ b/src/components/CommandPalette/index.tsx
@@ -9,7 +9,7 @@ import { useConnectionQueries } from 'src/hooks';
 
 const MAX_OPTION_TO_SHOW = 20;
 
-interface CommandPaletteProps {
+type CommandPaletteProps =  {
   onSelectCommand: (command: Command) => void;
 }
 

--- a/src/components/ConnectionActions/index.tsx
+++ b/src/components/ConnectionActions/index.tsx
@@ -20,7 +20,7 @@ import DropdownButton from 'src/components/DropdownButton';
 import Toast from 'src/components/Toast';
 import useToaster from 'src/hooks/useToaster';
 
-interface ConnectionActionsProps {
+type ConnectionActionsProps =  {
   connection: SqluiCore.ConnectionProps;
 }
 

--- a/src/components/ConnectionActions/index.tsx
+++ b/src/components/ConnectionActions/index.tsx
@@ -20,9 +20,9 @@ import DropdownButton from 'src/components/DropdownButton';
 import Toast from 'src/components/Toast';
 import useToaster from 'src/hooks/useToaster';
 
-type ConnectionActionsProps =  {
+type ConnectionActionsProps = {
   connection: SqluiCore.ConnectionProps;
-}
+};
 
 export default function ConnectionActions(props: ConnectionActionsProps) {
   const { connection } = props;

--- a/src/components/ConnectionForm/index.tsx
+++ b/src/components/ConnectionForm/index.tsx
@@ -95,7 +95,7 @@ export function EditConnectionForm(props: ConnectionFormProps) {
   );
 }
 
-type MainConnectionFormProps =  {
+type MainConnectionFormProps = {
   onSave: () => Promise<void>;
   name: string;
   setName: (newVal: string) => void;
@@ -103,7 +103,7 @@ type MainConnectionFormProps =  {
   setConnection: (newVal: string) => void;
   saving?: boolean;
   loading?: boolean;
-}
+};
 
 function MainConnectionForm(props: MainConnectionFormProps) {
   const navigate = useNavigate();

--- a/src/components/ConnectionForm/index.tsx
+++ b/src/components/ConnectionForm/index.tsx
@@ -95,7 +95,7 @@ export function EditConnectionForm(props: ConnectionFormProps) {
   );
 }
 
-interface MainConnectionFormProps {
+type MainConnectionFormProps =  {
   onSave: () => Promise<void>;
   name: string;
   setName: (newVal: string) => void;

--- a/src/components/ConnectionRetryAlert/index.tsx
+++ b/src/components/ConnectionRetryAlert/index.tsx
@@ -3,7 +3,7 @@ import Alert from '@mui/material/Alert';
 import { useState } from 'react';
 import { useRetryConnection } from 'src/hooks';
 
-interface ConnectionRetryAlertProps {
+type ConnectionRetryAlertProps =  {
   connectionId: string;
 }
 

--- a/src/components/ConnectionRetryAlert/index.tsx
+++ b/src/components/ConnectionRetryAlert/index.tsx
@@ -3,9 +3,9 @@ import Alert from '@mui/material/Alert';
 import { useState } from 'react';
 import { useRetryConnection } from 'src/hooks';
 
-type ConnectionRetryAlertProps =  {
+type ConnectionRetryAlertProps = {
   connectionId: string;
-}
+};
 
 export default function ConnectionRetryAlert(props: ConnectionRetryAlertProps) {
   const { connectionId } = props;

--- a/src/components/ConnectionTypeIcon/index.tsx
+++ b/src/components/ConnectionTypeIcon/index.tsx
@@ -1,9 +1,9 @@
 import CloudIcon from '@mui/icons-material/Cloud';
 
-type ConnectionTypeIconProps =  {
+type ConnectionTypeIconProps = {
   scheme?: string;
   status?: string;
-}
+};
 
 export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
   const { scheme, status } = props;

--- a/src/components/ConnectionTypeIcon/index.tsx
+++ b/src/components/ConnectionTypeIcon/index.tsx
@@ -1,6 +1,6 @@
 import CloudIcon from '@mui/icons-material/Cloud';
 
-interface ConnectionTypeIconProps {
+type ConnectionTypeIconProps =  {
   scheme?: string;
   status?: string;
 }

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -14,7 +14,7 @@ import { useSortBy } from 'react-table';
 import { useTable } from 'react-table';
 import React from 'react';
 
-interface DataTableProps {
+type DataTableProps =  {
   columns: any[];
   data: any[];
 }

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -14,10 +14,10 @@ import { useSortBy } from 'react-table';
 import { useTable } from 'react-table';
 import React from 'react';
 
-type DataTableProps =  {
+type DataTableProps = {
   columns: any[];
   data: any[];
-}
+};
 
 const pageSizeOptions: any[] = [10, 25, 50, 100, { label: 'Show All', value: -1 }];
 

--- a/src/components/DeleteConnectionButton/index.tsx
+++ b/src/components/DeleteConnectionButton/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useActionDialogs } from 'src/hooks/useActionDialogs';
 import { useDeleteConnection } from 'src/hooks';
 
-interface DeleteConnectionButtonProps {
+type DeleteConnectionButtonProps =  {
   connectionId: string;
 }
 

--- a/src/components/DeleteConnectionButton/index.tsx
+++ b/src/components/DeleteConnectionButton/index.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import { useActionDialogs } from 'src/hooks/useActionDialogs';
 import { useDeleteConnection } from 'src/hooks';
 
-type DeleteConnectionButtonProps =  {
+type DeleteConnectionButtonProps = {
   connectionId: string;
-}
+};
 
 export default function DeleteConnectionButton(props: DeleteConnectionButtonProps) {
   const { connectionId } = props;

--- a/src/components/DropdownButton/index.tsx
+++ b/src/components/DropdownButton/index.tsx
@@ -12,20 +12,20 @@ import Popper from '@mui/material/Popper';
 import { useEffect } from 'react';
 import React from 'react';
 
-type DropdownButtonOption =  {
+type DropdownButtonOption = {
   label: string;
   startIcon?: React.ReactNode;
   onClick?: () => void;
-}
+};
 
-type DropdownButtonProps =  {
+type DropdownButtonProps = {
   id: string;
   children: React.ReactNode;
   options: DropdownButtonOption[];
   onToggle?: (open: boolean) => void;
   open?: boolean;
   isLoading?: boolean;
-}
+};
 
 export default function DropdownButton(props: DropdownButtonProps) {
   const { id, options, children } = props;

--- a/src/components/DropdownButton/index.tsx
+++ b/src/components/DropdownButton/index.tsx
@@ -12,13 +12,13 @@ import Popper from '@mui/material/Popper';
 import { useEffect } from 'react';
 import React from 'react';
 
-interface DropdownButtonOption {
+type DropdownButtonOption =  {
   label: string;
   startIcon?: React.ReactNode;
   onClick?: () => void;
 }
 
-interface DropdownButtonProps {
+type DropdownButtonProps =  {
   id: string;
   children: React.ReactNode;
   options: DropdownButtonOption[];

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -35,7 +35,7 @@ import Settings from 'src/components/Settings';
 import useToaster from 'src/hooks/useToaster';
 import appPackage from 'src/package.json';
 
-export interface Command {
+export type Command =  {
   event: SqluiEnums.ClientEventKey;
   data?: unknown;
   label?: string;

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -35,11 +35,11 @@ import Settings from 'src/components/Settings';
 import useToaster from 'src/hooks/useToaster';
 import appPackage from 'src/package.json';
 
-export type Command =  {
+export type Command = {
   event: SqluiEnums.ClientEventKey;
   data?: unknown;
   label?: string;
-}
+};
 
 const QUERY_KEY_COMMAND_PALETTE = 'commandPalette';
 

--- a/src/components/QueryBox/ConnectionDatabaseSelector.tsx
+++ b/src/components/QueryBox/ConnectionDatabaseSelector.tsx
@@ -4,7 +4,7 @@ import { useGetConnections } from 'src/hooks';
 import { useGetDatabases } from 'src/hooks';
 import Select from 'src/components/Select';
 
-interface ConnectionDatabaseSelectorProps {
+type ConnectionDatabaseSelectorProps =  {
   value: SqluiFrontend.ConnectionQuery;
   onChange: (connectionId?: string, databaseId?: string) => void;
 }

--- a/src/components/QueryBox/ConnectionDatabaseSelector.tsx
+++ b/src/components/QueryBox/ConnectionDatabaseSelector.tsx
@@ -4,10 +4,10 @@ import { useGetConnections } from 'src/hooks';
 import { useGetDatabases } from 'src/hooks';
 import Select from 'src/components/Select';
 
-type ConnectionDatabaseSelectorProps =  {
+type ConnectionDatabaseSelectorProps = {
   value: SqluiFrontend.ConnectionQuery;
   onChange: (connectionId?: string, databaseId?: string) => void;
-}
+};
 
 export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSelectorProps) {
   const query = props.value;

--- a/src/components/QueryBox/ConnectionRevealButton.tsx
+++ b/src/components/QueryBox/ConnectionRevealButton.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { SqluiFrontend } from 'typings';
 import { useCommands } from 'src/components/MissionControl';
 
-interface ConnectionRevealButtonProps {
+type ConnectionRevealButtonProps =  {
   query: SqluiFrontend.ConnectionQuery;
 }
 

--- a/src/components/QueryBox/ConnectionRevealButton.tsx
+++ b/src/components/QueryBox/ConnectionRevealButton.tsx
@@ -4,9 +4,9 @@ import Tooltip from '@mui/material/Tooltip';
 import { SqluiFrontend } from 'typings';
 import { useCommands } from 'src/components/MissionControl';
 
-type ConnectionRevealButtonProps =  {
+type ConnectionRevealButtonProps = {
   query: SqluiFrontend.ConnectionQuery;
-}
+};
 
 export default function ConnectionRevealButton(props: ConnectionRevealButtonProps) {
   const { query } = props;

--- a/src/components/QueryBox/index.tsx
+++ b/src/components/QueryBox/index.tsx
@@ -23,7 +23,7 @@ import ConnectionRevealButton from 'src/components/QueryBox/ConnectionRevealButt
 import ResultBox from 'src/components/ResultBox';
 import Select from 'src/components/Select';
 
-interface QueryBoxProps {
+type QueryBoxProps =  {
   queryId: string;
 }
 

--- a/src/components/QueryBox/index.tsx
+++ b/src/components/QueryBox/index.tsx
@@ -23,9 +23,9 @@ import ConnectionRevealButton from 'src/components/QueryBox/ConnectionRevealButt
 import ResultBox from 'src/components/ResultBox';
 import Select from 'src/components/Select';
 
-type QueryBoxProps =  {
+type QueryBoxProps = {
   queryId: string;
-}
+};
 
 export default function QueryBox(props: QueryBoxProps) {
   const { queryId } = props;

--- a/src/components/Resizer/index.tsx
+++ b/src/components/Resizer/index.tsx
@@ -15,7 +15,7 @@ const StyledResizer = styled('div')(({ theme }) => {
 });
 
 // move this into a file
-interface ResizerProps {
+type ResizerProps =  {
   onSetWidth: (newWidth: number) => void;
 }
 

--- a/src/components/Resizer/index.tsx
+++ b/src/components/Resizer/index.tsx
@@ -15,9 +15,9 @@ const StyledResizer = styled('div')(({ theme }) => {
 });
 
 // move this into a file
-type ResizerProps =  {
+type ResizerProps = {
   onSetWidth: (newWidth: number) => void;
-}
+};
 
 const DRAG_GHOST_ID = 'drag-ghost';
 

--- a/src/components/ResultBox/index.tsx
+++ b/src/components/ResultBox/index.tsx
@@ -15,7 +15,7 @@ import DataTable from 'src/components/DataTable';
 import Tabs from 'src/components/Tabs';
 import Timer from 'src/components/Timer';
 
-interface ResultBoxProps {
+type ResultBoxProps =  {
   query: SqluiFrontend.ConnectionQuery;
   executing: boolean;
 }
@@ -129,7 +129,7 @@ export default function ResultBox(props: ResultBoxProps) {
   );
 }
 
-interface FormatDataProps {
+type FormatDataProps =  {
   data: any[];
 }
 
@@ -185,7 +185,7 @@ function TableFormatData(props: FormatDataProps) {
   return <DataTable columns={columns} data={data} />;
 }
 
-interface QueryTimeDescriptionProps {
+type QueryTimeDescriptionProps =  {
   query: SqluiFrontend.ConnectionQuery;
 }
 

--- a/src/components/ResultBox/index.tsx
+++ b/src/components/ResultBox/index.tsx
@@ -15,10 +15,10 @@ import DataTable from 'src/components/DataTable';
 import Tabs from 'src/components/Tabs';
 import Timer from 'src/components/Timer';
 
-type ResultBoxProps =  {
+type ResultBoxProps = {
   query: SqluiFrontend.ConnectionQuery;
   executing: boolean;
-}
+};
 
 export default function ResultBox(props: ResultBoxProps) {
   const [tabIdx, setTabIdx] = useState(0);
@@ -129,9 +129,9 @@ export default function ResultBox(props: ResultBoxProps) {
   );
 }
 
-type FormatDataProps =  {
+type FormatDataProps = {
   data: any[];
-}
+};
 
 function JsonFormatData(props: FormatDataProps) {
   const { data } = props;
@@ -185,9 +185,9 @@ function TableFormatData(props: FormatDataProps) {
   return <DataTable columns={columns} data={data} />;
 }
 
-type QueryTimeDescriptionProps =  {
+type QueryTimeDescriptionProps = {
   query: SqluiFrontend.ConnectionQuery;
-}
+};
 
 function QueryTimeDescription(props: QueryTimeDescriptionProps) {
   const { query } = props;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -8,7 +8,7 @@ import { useQuerySizeSetting } from 'src/hooks';
 import { useSettings } from 'src/hooks';
 import Select from 'src/components/Select';
 
-type SettingsProps =  {}
+type SettingsProps = {};
 
 export default function Settings(props: SettingsProps) {
   const { isLoading, settings, onChange } = useSettings();

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -8,7 +8,7 @@ import { useQuerySizeSetting } from 'src/hooks';
 import { useSettings } from 'src/hooks';
 import Select from 'src/components/Select';
 
-interface SettingsProps {}
+type SettingsProps =  {}
 
 export default function Settings(props: SettingsProps) {
   const { isLoading, settings, onChange } = useSettings();

--- a/src/components/SplitButton/index.tsx
+++ b/src/components/SplitButton/index.tsx
@@ -11,19 +11,19 @@ import Paper from '@mui/material/Paper';
 import Popper from '@mui/material/Popper';
 import React from 'react';
 
-type SplitButtonOption =  {
+type SplitButtonOption = {
   label: string;
   startIcon?: React.ReactNode;
   onClick: () => void;
-}
+};
 
-type SplitButtonProps =  {
+type SplitButtonProps = {
   id: string;
   label: string;
   startIcon?: React.ReactNode;
   onClick: () => void;
   options: SplitButtonOption[];
-}
+};
 
 export default function SplitButton(props: SplitButtonProps) {
   const { id, options, label } = props;

--- a/src/components/SplitButton/index.tsx
+++ b/src/components/SplitButton/index.tsx
@@ -11,13 +11,13 @@ import Paper from '@mui/material/Paper';
 import Popper from '@mui/material/Popper';
 import React from 'react';
 
-interface SplitButtonOption {
+type SplitButtonOption =  {
   label: string;
   startIcon?: React.ReactNode;
   onClick: () => void;
 }
 
-interface SplitButtonProps {
+type SplitButtonProps =  {
   id: string;
   label: string;
   startIcon?: React.ReactNode;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,13 +4,13 @@ import React from 'react';
 
 const VERTICAL_TAB_THRESHOLD = 20;
 
-type TabsProps =  {
+type TabsProps = {
   tabIdx: number;
   onTabChange: (newTabIdx: number) => void;
   tabHeaders: string[] | React.ReactNode[];
   tabContents: React.ReactNode[];
   orientation?: 'vertical' | 'horizontal';
-}
+};
 
 export default function MyTabs(props: TabsProps) {
   const { tabIdx, tabHeaders, tabContents } = props;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 const VERTICAL_TAB_THRESHOLD = 20;
 
-interface TabsProps {
+type TabsProps =  {
   tabIdx: number;
   onTabChange: (newTabIdx: number) => void;
   tabHeaders: string[] | React.ReactNode[];

--- a/src/components/TestConnectionButton/index.tsx
+++ b/src/components/TestConnectionButton/index.tsx
@@ -4,7 +4,7 @@ import { SqluiCore } from 'typings';
 import { useTestConnection } from 'src/hooks';
 import Toast from 'src/components/Toast';
 
-interface TestConnectionButtonProps {
+type TestConnectionButtonProps =  {
   connection: SqluiCore.CoreConnectionProps;
 }
 

--- a/src/components/TestConnectionButton/index.tsx
+++ b/src/components/TestConnectionButton/index.tsx
@@ -4,9 +4,9 @@ import { SqluiCore } from 'typings';
 import { useTestConnection } from 'src/hooks';
 import Toast from 'src/components/Toast';
 
-type TestConnectionButtonProps =  {
+type TestConnectionButtonProps = {
   connection: SqluiCore.CoreConnectionProps;
-}
+};
 
 export default function TestConnectionButton(props: TestConnectionButtonProps) {
   const [message, setMessage] = useState('');

--- a/src/components/Timer/index.tsx
+++ b/src/components/Timer/index.tsx
@@ -2,10 +2,10 @@ import { useEffect } from 'react';
 import { useRef } from 'react';
 import { useState } from 'react';
 
-type TimerProps =  {
+type TimerProps = {
   startTime?: number;
   endTime?: number;
-}
+};
 
 export default function _Timer(props: TimerProps) {
   const { startTime } = props;

--- a/src/components/Timer/index.tsx
+++ b/src/components/Timer/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useRef } from 'react';
 import { useState } from 'react';
 
-interface TimerProps {
+type TimerProps =  {
   startTime?: number;
   endTime?: number;
 }

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -2,7 +2,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 
-interface ToastProps {
+type ToastProps =  {
   open: boolean;
   onClose: () => void;
   message: string;

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -2,12 +2,12 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 
-type ToastProps =  {
+type ToastProps = {
   open: boolean;
   onClose: () => void;
   message: string;
   anchorOrigin?: AnchorOrigin;
-}
+};
 
 export type AnchorOrigin = {
   vertical?: 'bottom' | 'top';


### PR DESCRIPTION
Just to be consistent with the code. Now uses all `type` instead of `interface`.