### PR TITLE
Minor change to the selected Accordion headers and a few other minors styles tweaks

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -9,8 +9,8 @@ const StyledAccordionHeader = styled('div')(({ theme }) => {
     display: 'flex',
     alignItems: 'center',
     minHeight: '37px',
-    borderLeft: '3px solid transparent',
     paddingLeft: '3px',
+    gap: '5px',
 
     '&:hover': {
       backgroundColor: theme.palette.action.focus,
@@ -21,15 +21,7 @@ const StyledAccordionHeader = styled('div')(({ theme }) => {
     },
 
     '&.selected': {
-      borderColor: theme.palette.primary.main,
-    },
-
-    '*': {
-      marginRight: '5px',
-    },
-
-    '*:last-child': {
-      marginRight: 0,
+      backgroundColor: theme.palette.action.selected,
     },
 
     '> span': {

--- a/src/components/ConnectionTypeIcon/index.tsx
+++ b/src/components/ConnectionTypeIcon/index.tsx
@@ -19,7 +19,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'postgres':
@@ -28,7 +29,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'sqlite':
@@ -37,7 +39,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'mariadb':
@@ -46,7 +49,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'mysql':
@@ -55,7 +59,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'cassandra':
@@ -64,7 +69,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'mongodb':
@@ -73,7 +79,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     case 'redis':
@@ -82,7 +89,8 @@ export default function ConnectionTypeIcon(props: ConnectionTypeIconProps) {
           src={`${process.env.PUBLIC_URL}/assets/${scheme}.png`}
           alt={scheme}
           title={scheme}
-          width={30}
+          width={25}
+          height={25}
         />
       );
     default:

--- a/src/components/MissionControl/index.tsx
+++ b/src/components/MissionControl/index.tsx
@@ -189,8 +189,8 @@ export default function MissionControl() {
       message: `Revealed selected connection / database on the sidebar`,
     });
     setTimeout(() => {
-      //@ts-ignore
-      document.querySelector('.Accordion__Header.selected').scrollIntoView();
+      const selectedHeaders = document.querySelectorAll('.Accordion__Header.selected');
+      selectedHeaders[selectedHeaders.length - 1].scrollIntoView();
     }, 100);
   };
 


### PR DESCRIPTION
- Minor change to the selected Accordion headers. 
- Also now scroll to the last selected connection or database
- Minor style cleanups for the accordion headers
- Make connection icons a square now (25x25)

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/153768311-230ce89b-4083-4545-91b1-f3e919863c36.png)

