### PR TITLE
Moves the wordwrap option inline to save some vertical spaces and shows it only on hover

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -136,3 +136,21 @@ $ConnectionTreeIndentSize: 7px;
     }
   }
 }
+
+
+.CodeEditorBox{
+  position: relative;
+
+  .CodeEditorBox__WordWrap{
+    position: absolute;
+    bottom: 5px;
+    display: none;
+    right: 20px;
+  }
+
+  &:hover{
+    .CodeEditorBox__WordWrap{
+      display: flex;
+    }
+  }
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -137,19 +137,18 @@ $ConnectionTreeIndentSize: 7px;
   }
 }
 
-
-.CodeEditorBox{
+.CodeEditorBox {
   position: relative;
 
-  .CodeEditorBox__WordWrap{
+  .CodeEditorBox__WordWrap {
     position: absolute;
     bottom: 5px;
     display: none;
     right: 20px;
   }
 
-  &:hover{
-    .CodeEditorBox__WordWrap{
+  &:hover {
+    .CodeEditorBox__WordWrap {
       display: flex;
     }
   }

--- a/src/components/CodeEditorBox/index.tsx
+++ b/src/components/CodeEditorBox/index.tsx
@@ -27,16 +27,15 @@ export default function CodeEditorBox(props: CodeEditorProps) {
   };
 
   const contentToggleWordWrap = (
-    <div style={{ textAlign: 'right' }}>
-      <ToggleButton
-        value='check'
-        selected={wordWrap}
-        onChange={() => setWordWrap(!wordWrap)}
-        size='small'>
-        {wordWrap ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
-        <span style={{ marginLeft: '5px' }}>Wrap</span>
-      </ToggleButton>
-    </div>
+    <ToggleButton
+    className='CodeEditorBox__WordWrap'
+      value='check'
+      selected={wordWrap}
+      onChange={() => setWordWrap(!wordWrap)}
+      size='small'>
+      {wordWrap ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+      <span style={{ marginLeft: '5px' }}>Wrap</span>
+    </ToggleButton>
   );
 
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);

--- a/src/components/CodeEditorBox/index.tsx
+++ b/src/components/CodeEditorBox/index.tsx
@@ -28,7 +28,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
 
   const contentToggleWordWrap = (
     <ToggleButton
-    className='CodeEditorBox__WordWrap'
+      className='CodeEditorBox__WordWrap'
       value='check'
       selected={wordWrap}
       onChange={() => setWordWrap(!wordWrap)}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3792401/153937660-c6154dd8-3306-49be-8596-6c094c624ec1.png)
