### PR TITLE
Fix webpack when sequelize child dependencies not picked up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/components/ConnectionForm/ConnectionHint.tsx
@@ -46,7 +46,9 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample PostgresSQL connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('Postgres', 'postgres://postgres:password@localhost:5432')}>
+            onClick={() =>
+              props.onChange('Postgres', 'postgres://postgres:password@localhost:5432')
+            }>
             postgres://postgres:password@localhost:5432
           </Link>
         </Tooltip>
@@ -54,7 +56,9 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='sqlite' status='online' />}>
         <AlertTitle>SQLite</AlertTitle>
         <Tooltip title='Use this sample SQLite connection.'>
-          <Link underline='hover' onClick={() => props.onChange('Sqlite', 'sqlite://test-db.sqlite')}>
+          <Link
+            underline='hover'
+            onClick={() => props.onChange('Sqlite', 'sqlite://test-db.sqlite')}>
             sqlite://test-db.sqlite
           </Link>
         </Tooltip>
@@ -64,7 +68,9 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample Cassandra connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('Cassandra', 'cassandra://username:password@localhost:9042')}>
+            onClick={() =>
+              props.onChange('Cassandra', 'cassandra://username:password@localhost:9042')
+            }>
             cassandra://username:password@localhost:9042
           </Link>
         </Tooltip>
@@ -72,7 +78,9 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='mongodb' status='online' />}>
         <AlertTitle>MongoDB</AlertTitle>
         <Tooltip title='Use this sample MongoDB connection.'>
-          <Link underline='hover' onClick={() => props.onChange('Mongodb', 'mongodb://localhost:27017')}>
+          <Link
+            underline='hover'
+            onClick={() => props.onChange('Mongodb', 'mongodb://localhost:27017')}>
             mongodb://localhost:27017
           </Link>
         </Tooltip>

--- a/src/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/components/ConnectionForm/ConnectionHint.tsx
@@ -5,7 +5,7 @@ import Tooltip from '@mui/material/Tooltip';
 import ConnectionTypeIcon from 'src/components/ConnectionTypeIcon';
 
 type ConnectionHintProps = {
-  onChange: (connectionName: string) => void;
+  onChange: (dialect: string, connection: string) => void;
 };
 
 export default function ConnectionHint(props: ConnectionHintProps) {
@@ -16,7 +16,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample MySQL connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mysql://root:password@localhost:3306')}>
+            onClick={() => props.onChange('mysql', 'mysql://root:password@localhost:3306')}>
             mysql://root:password@localhost:3306
           </Link>
         </Tooltip>
@@ -26,7 +26,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample MariaDB connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mariadb://root:password@localhost:3306')}>
+            onClick={() => props.onChange('mariadb', 'mariadb://root:password@localhost:3306')}>
             mariadb://root:password@localhost:3306
           </Link>
         </Tooltip>
@@ -36,7 +36,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample Microsoft SQL Server connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mssql://sa:password123!@localhost:1433')}>
+            onClick={() => props.onChange('mssql', 'mssql://sa:password123!@localhost:1433')}>
             mssql://sa:password123!@localhost:1433
           </Link>
         </Tooltip>
@@ -46,7 +46,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample PostgresSQL connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('postgres://postgres:password@localhost:5432')}>
+            onClick={() => props.onChange('postgres', 'postgres://postgres:password@localhost:5432')}>
             postgres://postgres:password@localhost:5432
           </Link>
         </Tooltip>
@@ -54,7 +54,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='sqlite' status='online' />}>
         <AlertTitle>SQLite</AlertTitle>
         <Tooltip title='Use this sample SQLite connection.'>
-          <Link underline='hover' onClick={() => props.onChange('sqlite://test-db.sqlite')}>
+          <Link underline='hover' onClick={() => props.onChange('sqlite', 'sqlite://test-db.sqlite')}>
             sqlite://test-db.sqlite
           </Link>
         </Tooltip>
@@ -64,7 +64,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample Cassandra connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('cassandra://username:password@localhost:9042')}>
+            onClick={() => props.onChange('cassandra', 'cassandra://username:password@localhost:9042')}>
             cassandra://username:password@localhost:9042
           </Link>
         </Tooltip>
@@ -72,7 +72,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='mongodb' status='online' />}>
         <AlertTitle>MongoDB</AlertTitle>
         <Tooltip title='Use this sample MongoDB connection.'>
-          <Link underline='hover' onClick={() => props.onChange('mongodb://localhost:27017')}>
+          <Link underline='hover' onClick={() => props.onChange('mongodb', 'mongodb://localhost:27017')}>
             mongodb://localhost:27017
           </Link>
         </Tooltip>
@@ -80,7 +80,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='redis' status='online' />}>
         <AlertTitle>Redis</AlertTitle>
         <Tooltip title='Use this sample Redis connection.'>
-          <Link underline='hover' onClick={() => props.onChange('redis://localhost:6379')}>
+          <Link underline='hover' onClick={() => props.onChange('redis', 'redis://localhost:6379')}>
             redis://localhost:6379
           </Link>
         </Tooltip>

--- a/src/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/components/ConnectionForm/ConnectionHint.tsx
@@ -16,7 +16,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample MySQL connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mysql', 'mysql://root:password@localhost:3306')}>
+            onClick={() => props.onChange('Mysql', 'mysql://root:password@localhost:3306')}>
             mysql://root:password@localhost:3306
           </Link>
         </Tooltip>
@@ -26,7 +26,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample MariaDB connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mariadb', 'mariadb://root:password@localhost:3306')}>
+            onClick={() => props.onChange('Mariadb', 'mariadb://root:password@localhost:3306')}>
             mariadb://root:password@localhost:3306
           </Link>
         </Tooltip>
@@ -36,7 +36,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample Microsoft SQL Server connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('mssql', 'mssql://sa:password123!@localhost:1433')}>
+            onClick={() => props.onChange('Mssql', 'mssql://sa:password123!@localhost:1433')}>
             mssql://sa:password123!@localhost:1433
           </Link>
         </Tooltip>
@@ -46,7 +46,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample PostgresSQL connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('postgres', 'postgres://postgres:password@localhost:5432')}>
+            onClick={() => props.onChange('Postgres', 'postgres://postgres:password@localhost:5432')}>
             postgres://postgres:password@localhost:5432
           </Link>
         </Tooltip>
@@ -54,7 +54,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='sqlite' status='online' />}>
         <AlertTitle>SQLite</AlertTitle>
         <Tooltip title='Use this sample SQLite connection.'>
-          <Link underline='hover' onClick={() => props.onChange('sqlite', 'sqlite://test-db.sqlite')}>
+          <Link underline='hover' onClick={() => props.onChange('Sqlite', 'sqlite://test-db.sqlite')}>
             sqlite://test-db.sqlite
           </Link>
         </Tooltip>
@@ -64,7 +64,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
         <Tooltip title='Use this sample Cassandra connection.'>
           <Link
             underline='hover'
-            onClick={() => props.onChange('cassandra', 'cassandra://username:password@localhost:9042')}>
+            onClick={() => props.onChange('Cassandra', 'cassandra://username:password@localhost:9042')}>
             cassandra://username:password@localhost:9042
           </Link>
         </Tooltip>
@@ -72,7 +72,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='mongodb' status='online' />}>
         <AlertTitle>MongoDB</AlertTitle>
         <Tooltip title='Use this sample MongoDB connection.'>
-          <Link underline='hover' onClick={() => props.onChange('mongodb', 'mongodb://localhost:27017')}>
+          <Link underline='hover' onClick={() => props.onChange('Mongodb', 'mongodb://localhost:27017')}>
             mongodb://localhost:27017
           </Link>
         </Tooltip>
@@ -80,7 +80,7 @@ export default function ConnectionHint(props: ConnectionHintProps) {
       <Alert severity='info' icon={<ConnectionTypeIcon scheme='redis' status='online' />}>
         <AlertTitle>Redis</AlertTitle>
         <Tooltip title='Use this sample Redis connection.'>
-          <Link underline='hover' onClick={() => props.onChange('redis', 'redis://localhost:6379')}>
+          <Link underline='hover' onClick={() => props.onChange('Redis', 'redis://localhost:6379')}>
             redis://localhost:6379
           </Link>
         </Tooltip>

--- a/src/components/ConnectionForm/index.tsx
+++ b/src/components/ConnectionForm/index.tsx
@@ -130,6 +130,11 @@ function MainConnectionForm(props: MainConnectionFormProps) {
     connection: props.connection,
   };
 
+  const onApplyConnectionHint = (dialect, connection) => {
+    props.setName(`${dialect} Connection - ${new Date().toLocaleDateString()}`);
+    props.setConnection(connection)
+  }
+
   return (
     <form className='ConnectionForm FormInput__Container' onSubmit={onSave}>
       <div className='FormInput__Row'>
@@ -155,7 +160,7 @@ function MainConnectionForm(props: MainConnectionFormProps) {
       </div>
       {showHint && (
         <div className='FormInput__Container'>
-          <ConnectionHint onChange={props.setConnection} />
+          <ConnectionHint onChange={onApplyConnectionHint} />
         </div>
       )}
       <div className='FormInput__Row'>

--- a/src/components/ConnectionForm/index.tsx
+++ b/src/components/ConnectionForm/index.tsx
@@ -132,8 +132,8 @@ function MainConnectionForm(props: MainConnectionFormProps) {
 
   const onApplyConnectionHint = (dialect, connection) => {
     props.setName(`${dialect} Connection - ${new Date().toLocaleDateString()}`);
-    props.setConnection(connection)
-  }
+    props.setConnection(connection);
+  };
 
   return (
     <form className='ConnectionForm FormInput__Container' onSubmit={onSave}>

--- a/webpack-electron.config.js
+++ b/webpack-electron.config.js
@@ -13,6 +13,7 @@ module.exports = {
   externals: {
     electron: 'commonjs electron',
     'react-router-dom': 'commonjs react-router-dom',
+    sequelize: 'commonjs sequelize',
   },
   module: {
     rules: [

--- a/webpack-mocked-server.config.js
+++ b/webpack-mocked-server.config.js
@@ -13,6 +13,7 @@ module.exports = {
   externals: {
     electron: 'commonjs electron',
     'react-router-dom': 'commonjs react-router-dom',
+    sequelize: 'commonjs sequelize',
   },
   module: {
     rules: [


### PR DESCRIPTION
- Fix webpack build when sequelize child dependencies not picked up.
- Fixed up connection hint to automatically add the name as well as the connection string.

![image](https://user-images.githubusercontent.com/3792401/160004551-4d24eb9a-47ea-4d7f-a565-dc012aab15f5.png)
