### PR TITLE
UI to handle migration of raw JSON, clean up migration and new connection page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -154,6 +154,36 @@ export function getTableActions(tableActionInput: SqlAction.TableInput) {
   return _formatScripts(tableActionInput, scriptsToUse);
 }
 
+export function getSampleSelectQuery(tableActionInput: SqlAction.TableInput) {
+  let scriptsToUse: SqlAction.TableActionScriptGenerator[] = [];
+  switch (tableActionInput.dialect) {
+    case 'mysql':
+    case 'mariadb':
+    case 'mssql':
+    case 'postgres':
+    case 'sqlite':
+      scriptsToUse = RdbmsTableActionScripts;
+      break;
+    case 'cassandra':
+      scriptsToUse = CassandraTableActionScripts;
+      break;
+    case 'mongodb':
+      scriptsToUse = MongodbTableActionScripts;
+      break;
+    case 'redis':
+      scriptsToUse = RedisTableActionScripts;
+      break;
+    case 'cosmosdb':
+      scriptsToUse = AzureCosmosDBTableActionScripts;
+      break;
+    case 'aztable':
+      scriptsToUse = AzureTableTableActionScripts;
+      break;
+  }
+
+  return _formatScripts(tableActionInput, scriptsToUse).filter(script => script.label.includes('Select'))[0];
+}
+
 export function getDatabaseActions(databaseActionInput: SqlAction.DatabaseInput) {
   let scriptsToUse: SqlAction.DatabaseActionScriptGenerator[] = [];
   switch (databaseActionInput.dialect) {

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -181,7 +181,9 @@ export function getSampleSelectQuery(tableActionInput: SqlAction.TableInput) {
       break;
   }
 
-  return _formatScripts(tableActionInput, scriptsToUse).filter(script => script.label.includes('Select'))[0];
+  return _formatScripts(tableActionInput, scriptsToUse).filter((script) =>
+    script.label.includes('Select'),
+  )[0];
 }
 
 export function getDatabaseActions(databaseActionInput: SqlAction.DatabaseInput) {

--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -86,6 +86,7 @@ $ConnectionTreeIndentSize: 7px;
   &__Row {
     display: flex;
     gap: 2rem;
+    align-items: center;
   }
 }
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -147,9 +147,12 @@ export default function App() {
               <Route path='/' element={<MainPage />} />
               <Route path='/connection/new' element={<NewConnectionPage />} />
               <Route path='/connection/edit/:connectionId' element={<EditConnectionPage />} />
-              <Route path='/migration/real_connection' element={<MigrationPage  mode='real_connection' />} />
-              <Route path='/migration/raw_json' element={<MigrationPage  mode='raw_json' />} />
-              <Route path='/migration' element={<MigrationPage  />} />
+              <Route
+                path='/migration/real_connection'
+                element={<MigrationPage mode='real_connection' />}
+              />
+              <Route path='/migration/raw_json' element={<MigrationPage mode='raw_json' />} />
+              <Route path='/migration' element={<MigrationPage />} />
               <Route path='/*' element={<MainPage />} />
             </Routes>
           </section>

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -147,7 +147,9 @@ export default function App() {
               <Route path='/' element={<MainPage />} />
               <Route path='/connection/new' element={<NewConnectionPage />} />
               <Route path='/connection/edit/:connectionId' element={<EditConnectionPage />} />
-              <Route path='/migration' element={<MigrationPage />} />
+              <Route path='/migration/real_connection' element={<MigrationPage  mode='real_connection' />} />
+              <Route path='/migration/raw_json' element={<MigrationPage  mode='raw_json' />} />
+              <Route path='/migration' element={<MigrationPage  />} />
               <Route path='/*' element={<MainPage />} />
             </Routes>
           </section>

--- a/src/frontend/components/AppHeader/index.tsx
+++ b/src/frontend/components/AppHeader/index.tsx
@@ -1,5 +1,5 @@
 import AddIcon from '@mui/icons-material/Add';
-import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import BackupIcon from '@mui/icons-material/Backup';
 import EditIcon from '@mui/icons-material/Edit';
 import KeyboardCommandKeyIcon from '@mui/icons-material/KeyboardCommandKey';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -55,9 +55,9 @@ export default function AppHeader() {
       label: 'divider',
     },
     {
-      label: 'Connection / Data Migration',
+      label: 'Data Migration',
       onClick: () => navigate('/migration'),
-      startIcon: <CompareArrowsIcon />,
+      startIcon: <BackupIcon />,
     },
     {
       label: 'divider',

--- a/src/frontend/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/frontend/components/ConnectionForm/ConnectionHint.tsx
@@ -1,6 +1,4 @@
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
-import Link from '@mui/material/Link';
+import {Alert, AlertTitle, Link} from '@mui/material';
 import {
   getSampleConnectionString,
   SUPPORTED_DIALECTS,
@@ -29,12 +27,13 @@ export default function ConnectionHint(props: ConnectionHintProps) {
                 <ConnectionTypeIcon dialect={dialect} status='online' />
               </Link>
             }>
+
             <AlertTitle>
-              <Link underline='none' onClick={onApplyThisConnectionHint}>
+              <Link underline='hover' onClick={onApplyThisConnectionHint}>
                 <strong>{dialect}</strong>
               </Link>
             </AlertTitle>
-            <Link underline='none' onClick={onApplyThisConnectionHint}>
+            <Link underline='hover' onClick={onApplyThisConnectionHint}>
               {getSampleConnectionString(dialect)}
             </Link>
           </Alert>

--- a/src/frontend/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/frontend/components/ConnectionForm/ConnectionHint.tsx
@@ -1,4 +1,4 @@
-import {Alert, AlertTitle, Link} from '@mui/material';
+import { Alert, AlertTitle, Link } from '@mui/material';
 import {
   getSampleConnectionString,
   SUPPORTED_DIALECTS,
@@ -27,7 +27,6 @@ export default function ConnectionHint(props: ConnectionHintProps) {
                 <ConnectionTypeIcon dialect={dialect} status='online' />
               </Link>
             }>
-
             <AlertTitle>
               <Link underline='hover' onClick={onApplyThisConnectionHint}>
                 <strong>{dialect}</strong>

--- a/src/frontend/components/ConnectionForm/index.tsx
+++ b/src/frontend/components/ConnectionForm/index.tsx
@@ -1,7 +1,5 @@
 import SaveIcon from '@mui/icons-material/Save';
-import { Button } from '@mui/material';
-import Alert from '@mui/material/Alert';
-import TextField from '@mui/material/TextField';
+import { Button, Box, Alert, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import ConnectionHint from 'src/frontend/components/ConnectionForm/ConnectionHint';
@@ -18,6 +16,7 @@ type ConnectionFormProps = {
 export function NewConnectionForm() {
   const [name, setName] = useState('');
   const [connection, setConnection] = useState('');
+  const [showHint, setShowHint] = useState(true);
   const { mutateAsync, isLoading: saving } = useUpsertConnection();
   const navigate = useNavigate();
 
@@ -32,6 +31,28 @@ export function NewConnectionForm() {
     // when done, go back to the main page
     navigate(`/`, { replace: true });
   };
+
+  const onApplyConnectionHint = (dialect, connection) => {
+    setName(`${dialect} Connection - ${new Date().toLocaleDateString()}`);
+    setConnection(connection);
+    setShowHint(false);
+  };
+
+
+  if(showHint){
+    return <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
+      <Typography>Select one of the following connection type</Typography>
+      <ConnectionHint onChange={onApplyConnectionHint} />
+      <Box>
+        <Button
+        variant='outlined'
+        type='button'
+        onClick={() => navigate('/')}>
+        Cancel
+      </Button>
+      </Box>
+    </Box>;
+  }
 
   return (
     <MainConnectionForm

--- a/src/frontend/components/ConnectionForm/index.tsx
+++ b/src/frontend/components/ConnectionForm/index.tsx
@@ -1,5 +1,5 @@
 import SaveIcon from '@mui/icons-material/Save';
-import { Button, Box, Alert, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import ConnectionHint from 'src/frontend/components/ConnectionForm/ConnectionHint';
@@ -37,21 +37,18 @@ export function NewConnectionForm() {
     setConnection(connection);
     setShowHint(false);
   };
-
-
-  if(showHint){
-    return <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
-      <Typography>Select one of the following connection type</Typography>
-      <ConnectionHint onChange={onApplyConnectionHint} />
-      <Box>
-        <Button
-        variant='outlined'
-        type='button'
-        onClick={() => navigate('/')}>
-        Cancel
-      </Button>
+  if (showHint) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Typography>Select one of the following connection type</Typography>
+        <ConnectionHint onChange={onApplyConnectionHint} />
+        <Box>
+          <Button variant='outlined' type='button' onClick={() => navigate('/')}>
+            Cancel
+          </Button>
+        </Box>
       </Box>
-    </Box>;
+    );
   }
 
   return (

--- a/src/frontend/components/MigrationForm/index.tsx
+++ b/src/frontend/components/MigrationForm/index.tsx
@@ -1,10 +1,9 @@
 import MigrationBox from 'src/frontend/components/MigrationBox';
-import { SqluiFrontend } from 'typings';
 
 export function RealConnectionMigrationMigrationForm() {
   return <MigrationBox mode='real_connection' />;
 }
 
-export function RawJsonMigrationForm(){
+export function RawJsonMigrationForm() {
   return <MigrationBox mode='raw_json' />;
 }

--- a/src/frontend/components/MigrationForm/index.tsx
+++ b/src/frontend/components/MigrationForm/index.tsx
@@ -1,5 +1,10 @@
 import MigrationBox from 'src/frontend/components/MigrationBox';
+import { SqluiFrontend } from 'typings';
 
-export default function MigrationForm() {
-  return <MigrationBox />;
+export function RealConnectionMigrationMigrationForm() {
+  return <MigrationBox mode='real_connection' />;
+}
+
+export function RawJsonMigrationForm(){
+  return <MigrationBox mode='raw_json' />;
 }

--- a/src/frontend/components/NewConnectionButton/index.tsx
+++ b/src/frontend/components/NewConnectionButton/index.tsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import BackupIcon from '@mui/icons-material/Backup';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import { Button } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -25,9 +25,9 @@ export default function NewConnectionButton() {
       startIcon: <ArrowUpwardIcon />,
     },
     {
-      label: 'Connection / Data Migration',
+      label: 'Data Migration',
       onClick: () => navigate('/migration'),
-      startIcon: <CompareArrowsIcon />,
+      startIcon: <BackupIcon />,
     },
     {
       label: 'Collapse All Connections',

--- a/src/frontend/components/QueryBox/index.tsx
+++ b/src/frontend/components/QueryBox/index.tsx
@@ -1,4 +1,4 @@
-import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import BackupIcon from '@mui/icons-material/Backup';
 import FormatColorTextIcon from '@mui/icons-material/FormatColorText';
 import HelpIcon from '@mui/icons-material/Help';
 import SendIcon from '@mui/icons-material/Send';
@@ -123,7 +123,7 @@ export default function QueryBox(props: QueryBoxProps) {
 
   const onShowMigrationForThisDatabaseAndTable = () => {
     navigate(
-      `/migration?connectionId=${query?.connectionId || ''}&databaseId=${
+      `/migration/real_connection?connectionId=${query?.connectionId || ''}&databaseId=${
         query?.databaseId || ''
       }&tableId=${query?.tableId || ''}`,
     );
@@ -188,7 +188,7 @@ export default function QueryBox(props: QueryBoxProps) {
                 type='button'
                 variant='outlined'
                 onClick={onShowMigrationForThisDatabaseAndTable}
-                startIcon={<CompareArrowsIcon />}>
+                startIcon={<BackupIcon />}>
                 Migration
               </Button>
             </Tooltip>

--- a/src/frontend/views/MigrationPage/index.tsx
+++ b/src/frontend/views/MigrationPage/index.tsx
@@ -1,16 +1,38 @@
-import Typography from '@mui/material/Typography';
+import {Typography, Box, Link} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import { useEffect } from 'react';
 import ConnectionDescription from 'src/frontend/components/ConnectionDescription';
-import MigrationForm from 'src/frontend/components/MigrationForm';
+import {RealConnectionMigrationMigrationForm, RawJsonMigrationForm} from 'src/frontend/components/MigrationForm';
 import NewConnectionButton from 'src/frontend/components/NewConnectionButton';
 import Resizer from 'src/frontend/components/Resizer';
 import { useSideBarWidthPreference } from 'src/frontend/hooks/useClientSidePreference';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
+import { SqluiFrontend } from 'typings';
 
-export default function MigrationPage() {
+function MigrationOption(){
+  return <>
+    <Box>
+      <Link component={RouterLink} to="/migration/real_connection"><Typography>Migrate Real Connections</Typography></Link>
+      <Link component={RouterLink} to="/migration/raw_json"><Typography>Migrate Raw JSON</Typography></Link>
+    </Box>
+  </>
+}
+
+type MigrationPageProps = {
+  mode?: SqluiFrontend.MigrationMode;
+}
+
+export default function MigrationPage(props: MigrationPageProps) {
+  const {mode} = props;
   const { value: width, onChange: onSetWidth } = useSideBarWidthPreference();
-
   const { setTreeActions } = useTreeActions();
+
+  let contentDom = <MigrationOption />
+  if(mode === 'real_connection'){
+    contentDom = <RealConnectionMigrationMigrationForm />
+  } else if(mode ===  'raw_json'){
+    contentDom = <RawJsonMigrationForm />
+  }
 
   useEffect(() => {
     setTreeActions({
@@ -29,7 +51,7 @@ export default function MigrationPage() {
         <Typography variant='h5' gutterBottom={true} sx={{ mt: 1 }}>
           Migration
         </Typography>
-        <MigrationForm />
+        {contentDom}
       </div>
     </section>
   );

--- a/src/frontend/views/MigrationPage/index.tsx
+++ b/src/frontend/views/MigrationPage/index.tsx
@@ -1,42 +1,52 @@
-import {Typography, Box, Link} from '@mui/material';
+import { Box, Link, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { useEffect } from 'react';
 import ConnectionDescription from 'src/frontend/components/ConnectionDescription';
-import {RealConnectionMigrationMigrationForm, RawJsonMigrationForm} from 'src/frontend/components/MigrationForm';
+import {
+  RawJsonMigrationForm,
+  RealConnectionMigrationMigrationForm,
+} from 'src/frontend/components/MigrationForm';
 import NewConnectionButton from 'src/frontend/components/NewConnectionButton';
 import Resizer from 'src/frontend/components/Resizer';
 import { useSideBarWidthPreference } from 'src/frontend/hooks/useClientSidePreference';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import { SqluiFrontend } from 'typings';
-
-function MigrationOption(){
-  return <>
-    <Box sx={{display:'flex', gap: 2, flexDirection: 'column'}}>
-      <Typography variant='h6'>Select a migration option:</Typography>
-      <Link component={RouterLink} to="/migration/real_connection"><Typography >Migrate Real Existing Connections</Typography></Link>
-      <Link component={RouterLink} to="/migration/raw_json"><Typography >Migrate Raw JSON Data</Typography></Link>
-      <Link component={RouterLink} to="/"><Typography >Back to Main Query Page</Typography></Link>
-    </Box>
-  </>
+function MigrationOption() {
+  return (
+    <>
+      <Box sx={{ display: 'flex', gap: 2, flexDirection: 'column' }}>
+        <Typography variant='h6'>Select a migration option:</Typography>
+        <Link component={RouterLink} to='/migration/real_connection'>
+          <Typography>Migrate Real Existing Connections</Typography>
+        </Link>
+        <Link component={RouterLink} to='/migration/raw_json'>
+          <Typography>Migrate Raw JSON Data</Typography>
+        </Link>
+        <Link component={RouterLink} to='/'>
+          <Typography>Back to Main Query Page</Typography>
+        </Link>
+      </Box>
+    </>
+  );
 }
 
 type MigrationPageProps = {
   mode?: SqluiFrontend.MigrationMode;
-}
+};
 
 export default function MigrationPage(props: MigrationPageProps) {
-  const {mode} = props;
+  const { mode } = props;
   const { value: width, onChange: onSetWidth } = useSideBarWidthPreference();
   const { setTreeActions } = useTreeActions();
 
   let titleDom = 'Migration';
-  let contentDom = <MigrationOption />
-  if(mode === 'real_connection'){
+  let contentDom = <MigrationOption />;
+  if (mode === 'real_connection') {
     titleDom = 'Migration of Real Existing Connection';
-    contentDom = <RealConnectionMigrationMigrationForm />
-  } else if(mode ===  'raw_json'){
+    contentDom = <RealConnectionMigrationMigrationForm />;
+  } else if (mode === 'raw_json') {
     titleDom = 'Migration of Raw JSON Data';
-    contentDom = <RawJsonMigrationForm />
+    contentDom = <RawJsonMigrationForm />;
   }
 
   useEffect(() => {

--- a/src/frontend/views/MigrationPage/index.tsx
+++ b/src/frontend/views/MigrationPage/index.tsx
@@ -11,9 +11,11 @@ import { SqluiFrontend } from 'typings';
 
 function MigrationOption(){
   return <>
-    <Box>
-      <Link component={RouterLink} to="/migration/real_connection"><Typography>Migrate Real Connections</Typography></Link>
-      <Link component={RouterLink} to="/migration/raw_json"><Typography>Migrate Raw JSON</Typography></Link>
+    <Box sx={{display:'flex', gap: 2, flexDirection: 'column'}}>
+      <Typography variant='h6'>Select a migration option:</Typography>
+      <Link component={RouterLink} to="/migration/real_connection"><Typography >Migrate Real Existing Connections</Typography></Link>
+      <Link component={RouterLink} to="/migration/raw_json"><Typography >Migrate Raw JSON Data</Typography></Link>
+      <Link component={RouterLink} to="/"><Typography >Back to Main Query Page</Typography></Link>
     </Box>
   </>
 }
@@ -27,10 +29,13 @@ export default function MigrationPage(props: MigrationPageProps) {
   const { value: width, onChange: onSetWidth } = useSideBarWidthPreference();
   const { setTreeActions } = useTreeActions();
 
+  let titleDom = 'Migration';
   let contentDom = <MigrationOption />
   if(mode === 'real_connection'){
+    titleDom = 'Migration of Real Existing Connection';
     contentDom = <RealConnectionMigrationMigrationForm />
   } else if(mode ===  'raw_json'){
+    titleDom = 'Migration of Raw JSON Data';
     contentDom = <RawJsonMigrationForm />
   }
 
@@ -49,7 +54,7 @@ export default function MigrationPage(props: MigrationPageProps) {
       <Resizer onSetWidth={onSetWidth} />
       <div className='LayoutTwoColumns__RightPane'>
         <Typography variant='h5' gutterBottom={true} sx={{ mt: 1 }}>
-          Migration
+          {titleDom}
         </Typography>
         {contentDom}
       </div>

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -160,6 +160,8 @@ export module SqluiFrontend {
     | 'settings';
 
   export type MigrationType = 'insert' | 'create';
+
+  export type MigrationMode = 'real_connection' | 'raw_json';
 }
 
 export module SqlAction {


### PR DESCRIPTION
- New connection page
- Migration Main Page
- Migration of JSON
- Migration of Real connection
- New icons for migration

### New connection page
- Allows user to select a migration template
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/3792401/174330907-56d44ba5-d165-4c83-9260-e6de7a842b68.png">

### Migration Main Page
- Will present 2 options to do migration
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/3792401/174331552-5a19af32-b877-47a4-81c5-033973133035.png">


### Migration of JSON
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/3792401/174331047-28b5dd73-f8b8-42c5-9f8b-4e26c8749b4d.png">

### Migration of Real connection
- Now remove the migration type (insert vs create), we will do both and show the data accordingly
- Add a button to apply sample query to help selection
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/3792401/174331442-7d4b6c65-68f8-4e4d-9168-8f066b30aee2.png">

