### PR TITLE
Add an option to override the detected language in the editor

### DIFF
--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -137,7 +137,7 @@ $ConnectionTreeIndentSize: 7px;
     gap: 1rem;
   }
 
-  &:hover{
+  &:hover {
     .CodeEditorBox__Commands {
       display: flex;
       margin-left: auto;

--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -130,16 +130,16 @@ $ConnectionTreeIndentSize: 7px;
 .CodeEditorBox {
   position: relative;
 
-  .CodeEditorBox__WordWrap {
-    position: absolute;
-    bottom: 5px;
-    display: none;
-    right: 20px;
+  .CodeEditorBox__Commands {
+    // display: none;
+    display: flex;
+        justify-content: end;
   }
 
-  &:hover {
-    .CodeEditorBox__WordWrap {
+  &:hover{
+    .CodeEditorBox__Commands {
       display: flex;
+      margin-left: auto;
     }
   }
 }

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -2,12 +2,12 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import Paper from '@mui/material/Paper';
 import ToggleButton from '@mui/material/ToggleButton';
-import Button from '@mui/material/Button';
 import { useEffect, useState } from 'react';
 import AdvancedEditor from 'src/frontend/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/frontend/components/CodeEditorBox/SimpleEditor';
-import { useEditorModeSetting, useWordWrapSetting } from 'src/frontend/hooks/useSetting';
 import Select from 'src/frontend/components/Select';
+import { useEditorModeSetting, useWordWrapSetting } from 'src/frontend/hooks/useSetting';
+
 type CodeEditorProps = {
   value?: string;
   onChange?: (newValue: string) => void;
@@ -51,14 +51,14 @@ export default function CodeEditorBox(props: CodeEditorProps) {
     </>
   );
 
-  const editorOptionBox = <div className='CodeEditorBox__Commands'>
-        {contentToggleWordWrap}
-        {contentLanguageMode}
-        </div>;
+  const editorOptionBox = (
+    <div className='CodeEditorBox__Commands'>
+      {contentToggleWordWrap}
+      {contentLanguageMode}
+    </div>
+  );
 
   const languageToUse = languageMode || props.language;
-
-
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);
 
   if (editorModeToUse === 'simple') {

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -2,6 +2,7 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import Paper from '@mui/material/Paper';
 import ToggleButton from '@mui/material/ToggleButton';
+import Button from '@mui/material/Button';
 import { useEffect, useState } from 'react';
 import AdvancedEditor from 'src/frontend/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/frontend/components/CodeEditorBox/SimpleEditor';
@@ -29,7 +30,6 @@ export default function CodeEditorBox(props: CodeEditorProps) {
 
   const contentToggleWordWrap = (
     <ToggleButton
-      className='CodeEditorBox__WordWrap'
       value='check'
       selected={wordWrap}
       onChange={() => setWordWrap(!wordWrap)}
@@ -39,6 +39,22 @@ export default function CodeEditorBox(props: CodeEditorProps) {
       <span style={{ marginLeft: '5px' }}>Wrap</span>
     </ToggleButton>
   );
+
+  const contentLanguageMode = (
+    <Button
+      value='check'
+      onChange={() => setWordWrap(!wordWrap)}
+      size='small'
+      color='primary'>
+      <span style={{ marginLeft: '5px' }}>Wrap</span>
+    </Button>
+  );
+
+
+  const editorOptionBox = <div className='CodeEditorBox__Commands'>
+        {contentToggleWordWrap}
+        {contentLanguageMode}
+        </div>;
 
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);
 
@@ -54,7 +70,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
           disabled={props.disabled}
           wordWrap={wordWrap}
         />
-        {contentToggleWordWrap}
+        {editorOptionBox}
       </div>
     );
   }
@@ -69,7 +85,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
         placeholder={props.placeholder}
         disabled={props.disabled}
       />
-      {contentToggleWordWrap}
+      {editorOptionBox}
     </Paper>
   );
 }


### PR DESCRIPTION
Fixes #332

Some engine like Azure CosmosDB supports both the javascript and SQL syntax, it's good to allow user to override the detected syntax mode.



![image](https://user-images.githubusercontent.com/3792401/176459546-06ccc4d9-70d6-4da7-9775-e6e844c06c26.png)
![image](https://user-images.githubusercontent.com/3792401/176459622-6419f2b5-8112-46ab-b579-6e0144bacb2d.png)

