### PR TITLE
Added an option to override the height of the editor

### DIFF
--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -131,15 +131,16 @@ $ConnectionTreeIndentSize: 7px;
   position: relative;
 
   .CodeEditorBox__Commands {
-    display: none;
+    display: flex;
     justify-content: end;
     gap: 1rem;
+    transition: all 0.5s;
+    transform: scaleY(0);
   }
 
   &:hover {
     .CodeEditorBox__Commands {
-      display: flex;
-      margin-left: auto;
+      transform: none;
     }
   }
 }
@@ -156,6 +157,6 @@ $ConnectionTreeIndentSize: 7px;
 // remove transition
 @media (prefers-reduced-motion) {
   * {
-    transition-duration: 0s !important;
+    transition-duration: 0.25s !important;
   }
 }

--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -130,16 +130,16 @@ $ConnectionTreeIndentSize: 7px;
 .CodeEditorBox {
   position: relative;
 
-  .CodeEditorBox__WordWrap {
-    position: absolute;
-    bottom: 5px;
-    display: none;
-    right: 20px;
+  .CodeEditorBox__Commands {
+    // display: none;
+    display: flex;
+        justify-content: end;
   }
 
-  &:hover {
-    .CodeEditorBox__WordWrap {
+  &:hover{
+    .CodeEditorBox__Commands {
       display: flex;
+      margin-left: auto;
     }
   }
 }

--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
@@ -101,6 +101,7 @@ export default function AdvancedEditor(props: AdvancedEditorProps) {
       className='AdvancedEditorContainer'
       ref={monacoEl}
       style={{
-    height: props.height,}}></AdvancedEditorContainer>
+        height: props.height,
+      }}></AdvancedEditorContainer>
   );
 }

--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
@@ -12,11 +12,11 @@ type AdvancedEditorProps = {
   wordWrap?: boolean;
   placeholder?: string;
   disabled?: boolean;
+  height?: string;
 };
 
 const AdvancedEditorContainer = styled('div')(({ theme }) => {
   return {
-    height: '300px',
     width: '100%',
   };
 });
@@ -99,6 +99,8 @@ export default function AdvancedEditor(props: AdvancedEditorProps) {
   return (
     <AdvancedEditorContainer
       className='AdvancedEditorContainer'
-      ref={monacoEl}></AdvancedEditorContainer>
+      ref={monacoEl}
+      style={{
+    height: '250px',}}></AdvancedEditorContainer>
   );
 }

--- a/src/frontend/components/CodeEditorBox/SimpleEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/SimpleEditor.tsx
@@ -21,7 +21,6 @@ const StyledTextArea = styled('textarea')(({ theme }) => {
     fontFamily: 'monospace',
     fontWeight: '700',
     width: '100%',
-    minHeight: '300px',
     padding: '10px',
     resize: 'vertical',
     outline: 'none',
@@ -189,6 +188,7 @@ export default function SchemaEditor(props) {
       required={props.required}
       style={{
         whiteSpace: props.wordWrap ? 'initial' : 'nowrap',
+        minHeight: props.height,
       }}
     />
   );

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -19,6 +19,8 @@ type CodeEditorProps = {
   disabled?: boolean;
 };
 
+const EDITOR_HEIGHT = '20vh'
+
 export default function CodeEditorBox(props: CodeEditorProps) {
   const globalWordWrap = useWordWrapSetting();
   const [wordWrap, setWordWrap] = useState(false);
@@ -57,7 +59,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
         </div>;
 
   const languageToUse = languageMode || props.language;
-
+  const height = EDITOR_HEIGHT;
 
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);
 
@@ -72,6 +74,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
           required={props.required}
           disabled={props.disabled}
           wordWrap={wordWrap}
+          height={height}
         />
         {editorOptionBox}
       </div>
@@ -87,6 +90,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
         wordWrap={wordWrap}
         placeholder={props.placeholder}
         disabled={props.disabled}
+        height={height}
       />
       {editorOptionBox}
     </Paper>

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -19,19 +19,20 @@ type CodeEditorProps = {
   disabled?: boolean;
 };
 
-const EDITOR_HEIGHT = '20vh'
+const DEFAULT_EDITOR_HEIGHT = '20vh'
 
 export default function CodeEditorBox(props: CodeEditorProps) {
   const globalWordWrap = useWordWrapSetting();
   const [wordWrap, setWordWrap] = useState(false);
   const [languageMode, setLanguageMode] = useState<string | undefined>();
+  const [height, setHeight] = useState<string>(DEFAULT_EDITOR_HEIGHT);
   const editorModeToUse = useEditorModeSetting();
 
   const onChange = (newValue: string) => {
     props.onChange && props.onChange(newValue);
   };
 
-  const contentToggleWordWrap = (
+  const contentToggleWordWrapSelection = (
     <ToggleButton
       value='check'
       selected={wordWrap}
@@ -43,7 +44,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
     </ToggleButton>
   );
 
-  const contentLanguageMode = (
+  const contentLanguageModeSelection = (
     <>
       <Select onChange={(newLanguage) => setLanguageMode(newLanguage)} value={languageMode}>
         <option value=''>Auto Detected ({props.language})</option>
@@ -53,13 +54,23 @@ export default function CodeEditorBox(props: CodeEditorProps) {
     </>
   );
 
+  const contentHeightSelection = (
+    <>
+      <Select onChange={(newHeight) => setHeight(newHeight)} value={height}>
+        <option value='20vh'>Small Editor</option>
+        <option value='40vh'>Medium Editor</option>
+        <option value='60vh'>Large Editor</option>
+      </Select>
+    </>
+  );
+
   const editorOptionBox = <div className='CodeEditorBox__Commands'>
-        {contentToggleWordWrap}
-        {contentLanguageMode}
+        {contentToggleWordWrapSelection}
+        {contentHeightSelection}
+        {contentLanguageModeSelection}
         </div>;
 
   const languageToUse = languageMode || props.language;
-  const height = EDITOR_HEIGHT;
 
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);
 

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -2,12 +2,12 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import Paper from '@mui/material/Paper';
 import ToggleButton from '@mui/material/ToggleButton';
-import Button from '@mui/material/Button';
 import { useEffect, useState } from 'react';
 import AdvancedEditor from 'src/frontend/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/frontend/components/CodeEditorBox/SimpleEditor';
 import Select from 'src/frontend/components/Select';
 import { useEditorModeSetting, useWordWrapSetting } from 'src/frontend/hooks/useSetting';
+
 type CodeEditorProps = {
   value?: string;
   onChange?: (newValue: string) => void;
@@ -19,7 +19,7 @@ type CodeEditorProps = {
   disabled?: boolean;
 };
 
-const DEFAULT_EDITOR_HEIGHT = '20vh'
+const DEFAULT_EDITOR_HEIGHT = '20vh';
 
 export default function CodeEditorBox(props: CodeEditorProps) {
   const globalWordWrap = useWordWrapSetting();
@@ -64,11 +64,13 @@ export default function CodeEditorBox(props: CodeEditorProps) {
     </>
   );
 
-  const editorOptionBox = <div className='CodeEditorBox__Commands'>
-        {contentToggleWordWrapSelection}
-        {contentHeightSelection}
-        {contentLanguageModeSelection}
-        </div>;
+  const editorOptionBox = (
+    <div className='CodeEditorBox__Commands'>
+      {contentToggleWordWrapSelection}
+      {contentHeightSelection}
+      {contentLanguageModeSelection}
+    </div>
+  );
 
   const languageToUse = languageMode || props.language;
 

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -2,6 +2,7 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import Paper from '@mui/material/Paper';
 import ToggleButton from '@mui/material/ToggleButton';
+import Button from '@mui/material/Button';
 import { useEffect, useState } from 'react';
 import AdvancedEditor from 'src/frontend/components/CodeEditorBox/AdvancedEditor';
 import SimpleEditor from 'src/frontend/components/CodeEditorBox/SimpleEditor';
@@ -29,7 +30,6 @@ export default function CodeEditorBox(props: CodeEditorProps) {
 
   const contentToggleWordWrap = (
     <ToggleButton
-      className='CodeEditorBox__WordWrap'
       value='check'
       selected={wordWrap}
       onChange={() => setWordWrap(!wordWrap)}
@@ -39,6 +39,22 @@ export default function CodeEditorBox(props: CodeEditorProps) {
       <span style={{ marginLeft: '5px' }}>Wrap</span>
     </ToggleButton>
   );
+
+  const contentLanguageMode = (
+    <Button
+      value='check'
+      onChange={() => setWordWrap(!wordWrap)}
+      size='small'
+      color='primary'>
+      <span style={{ marginLeft: '5px' }}>Wrap</span>
+    </Button>
+  );
+
+
+  const editorOptionBox = <div className='CodeEditorBox__Commands'>
+        {contentToggleWordWrap}
+        {contentLanguageMode}
+        </div>;
 
   useEffect(() => setWordWrap(!!props.wordWrap || globalWordWrap), [globalWordWrap]);
 
@@ -54,7 +70,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
           disabled={props.disabled}
           wordWrap={wordWrap}
         />
-        {contentToggleWordWrap}
+        {editorOptionBox}
       </div>
     );
   }
@@ -69,7 +85,7 @@ export default function CodeEditorBox(props: CodeEditorProps) {
         placeholder={props.placeholder}
         disabled={props.disabled}
       />
-      {contentToggleWordWrap}
+      {editorOptionBox}
     </Paper>
   );
 }


### PR DESCRIPTION
- Added an option to override the height of the editor
- Added minor animation for the showing and hiding of the bottom bar

### Small Editor Height
![image](https://user-images.githubusercontent.com/3792401/176463345-646b6fdf-ac3f-4d93-9d59-0d257b69c7dc.png)

### Medium Editor Height
![image](https://user-images.githubusercontent.com/3792401/176463439-cd4aaeb9-96d7-4eeb-ab31-3eee4d522338.png)

### Large Editor Height
![image](https://user-images.githubusercontent.com/3792401/176463559-25dcb0ad-43ae-4d0b-ab78-125154da49a9.png)

