### PR TITLE
Better way to render different types of values in the Record Details Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -152,13 +152,13 @@ $ConnectionTreeIndentSize: 7px;
   }
 }
 
-.RawHtmlRender{
-  > *{
-    &:first-child{
+.RawHtmlRender {
+  > * {
+    &:first-child {
       margin-top: 0;
     }
 
-    &:last-child{
+    &:last-child {
       margin-bottom: 0;
     }
   }

--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -152,6 +152,18 @@ $ConnectionTreeIndentSize: 7px;
   }
 }
 
+.RawHtmlRender{
+  > *{
+    &:first-child{
+      margin-top: 0;
+    }
+
+    &:last-child{
+      margin-bottom: 0;
+    }
+  }
+}
+
 // remove transition
 @media (prefers-reduced-motion) {
   * {

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -19,6 +19,8 @@ import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import LayoutTwoColumns from 'src/frontend/layout/LayoutTwoColumns';
 import { formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
+import FilledInput from '@mui/material/FilledInput';
+import InputLabel from '@mui/material/InputLabel';
 
 type RecordData = any;
 
@@ -296,12 +298,27 @@ export function RecordDetailsPage(props: RecordDetailsPageProps) {
   const tabHeaders = [<>Form Display</>, <>Raw JSON</>];
 
   const tabContents = [
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }} key='formDisplay'>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }} key='formDisplay'>
       {columnNames.map((columnName) => {
+        const columnValue = data[columnName];
+
+        let contentColumnValue = <TextField value={columnValue} size='small' margin="dense" disabled={true} />;
+        if(columnValue === true || columnValue === false){
+          // boolean
+        } else if(columnValue === null){
+          // null value
+          contentColumnValue = <TextField value='<NULL>' size='small'  margin="dense" disabled={true} />;
+        }  else if(columnValue === undefined){
+          // undefined
+          contentColumnValue = <TextField value='<undefined>' size='small'  margin="dense" disabled={true} />;
+        } else if(columnValue?.toString()?.match(/<[a-z0-9]>+/gi) || columnValue?.toString()?.match(/<\/[a-z0-9]+>/gi)){
+          contentColumnValue = <Box className='RawHtmlRender' dangerouslySetInnerHTML={{ __html: columnValue }} sx={{border: 1, borderRadius: 1, borderColor: 'divider', p: 1}}/>
+        }
+
         return (
           <React.Fragment key={columnName}>
-            <Typography sx={{ fontWeight: 'bold' }}>{columnName}</Typography>
-            <TextField value={data[columnName]} size='small' disabled={true} />
+            <InputLabel sx={{mt: 1, fontWeight:'bold'}}>{columnName}</InputLabel>
+            {contentColumnValue}
           </React.Fragment>
         );
       })}

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -305,6 +305,8 @@ export function RecordDetailsPage(props: RecordDetailsPageProps) {
         let contentColumnValue = <TextField value={columnValue} size='small' margin="dense" disabled={true} />;
         if(columnValue === true || columnValue === false){
           // boolean
+          const booleanLabel = columnValue ? '<TRUE>' : '<FALSE>';
+          contentColumnValue = <TextField value={columnValue} size='small'  margin="dense" disabled={true} />;
         } else if(columnValue === null){
           // null value
           contentColumnValue = <TextField value='<NULL>' size='small'  margin="dense" disabled={true} />;

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -314,7 +314,14 @@ export function RecordDetailsPage(props: RecordDetailsPageProps) {
           // undefined
           contentColumnValue = <TextField value='<undefined>' size='small'  margin="dense" disabled={true} />;
         } else if(columnValue?.toString()?.match(/<[a-z0-9]>+/gi) || columnValue?.toString()?.match(/<\/[a-z0-9]+>/gi)){
+          // raw HTML
           contentColumnValue = <Box className='RawHtmlRender' dangerouslySetInnerHTML={{ __html: columnValue }} sx={{border: 1, borderRadius: 1, borderColor: 'divider', p: 1}}/>
+        } else if(Array.isArray(columnValue) || typeof columnValue === 'object'){
+          // complex object (array or plain object)
+          contentColumnValue = <TextField value={JSON.stringify(columnValue, null, 2)} size='small' margin="dense" disabled={true} multiline inputProps={{style: {fontFamily: 'monospace'}}} />;
+        } else if(columnValue?.toString()?.length > 200){
+          // greater than a limit, then render as a multiple lines
+           contentColumnValue = <TextField value={columnValue} size='small' margin="dense" disabled={true} multiline/>;
         }
 
         return (

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -1,8 +1,8 @@
 import EditIcon from '@mui/icons-material/Edit';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import InputLabel from '@mui/material/InputLabel';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { getInsert as getInsertForRdmbs } from 'src/common/adapters/RelationalDataAdapter/scripts';
@@ -19,8 +19,6 @@ import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import LayoutTwoColumns from 'src/frontend/layout/LayoutTwoColumns';
 import { formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
-import FilledInput from '@mui/material/FilledInput';
-import InputLabel from '@mui/material/InputLabel';
 
 type RecordData = any;
 
@@ -302,31 +300,59 @@ export function RecordDetailsPage(props: RecordDetailsPageProps) {
       {columnNames.map((columnName) => {
         const columnValue = data[columnName];
 
-        let contentColumnValue = <TextField value={columnValue} size='small' margin="dense" disabled={true} />;
-        if(columnValue === true || columnValue === false){
+        let contentColumnValue = (
+          <TextField value={columnValue} size='small' margin='dense' disabled={true} />
+        );
+        if (columnValue === true || columnValue === false) {
           // boolean
           const booleanLabel = columnValue ? '<TRUE>' : '<FALSE>';
-          contentColumnValue = <TextField value={columnValue} size='small'  margin="dense" disabled={true} />;
-        } else if(columnValue === null){
+          contentColumnValue = (
+            <TextField value={columnValue} size='small' margin='dense' disabled={true} />
+          );
+        } else if (columnValue === null) {
           // null value
-          contentColumnValue = <TextField value='<NULL>' size='small'  margin="dense" disabled={true} />;
-        }  else if(columnValue === undefined){
+          contentColumnValue = (
+            <TextField value='<NULL>' size='small' margin='dense' disabled={true} />
+          );
+        } else if (columnValue === undefined) {
           // undefined
-          contentColumnValue = <TextField value='<undefined>' size='small'  margin="dense" disabled={true} />;
-        } else if(columnValue?.toString()?.match(/<[a-z0-9]>+/gi) || columnValue?.toString()?.match(/<\/[a-z0-9]+>/gi)){
+          contentColumnValue = (
+            <TextField value='<undefined>' size='small' margin='dense' disabled={true} />
+          );
+        } else if (
+          columnValue?.toString()?.match(/<[a-z0-9]>+/gi) ||
+          columnValue?.toString()?.match(/<\/[a-z0-9]+>/gi)
+        ) {
           // raw HTML
-          contentColumnValue = <Box className='RawHtmlRender' dangerouslySetInnerHTML={{ __html: columnValue }} sx={{border: 1, borderRadius: 1, borderColor: 'divider', p: 1}}/>
-        } else if(Array.isArray(columnValue) || typeof columnValue === 'object'){
+          contentColumnValue = (
+            <Box
+              className='RawHtmlRender'
+              dangerouslySetInnerHTML={{ __html: columnValue }}
+              sx={{ border: 1, borderRadius: 1, borderColor: 'divider', p: 1 }}
+            />
+          );
+        } else if (Array.isArray(columnValue) || typeof columnValue === 'object') {
           // complex object (array or plain object)
-          contentColumnValue = <TextField value={JSON.stringify(columnValue, null, 2)} size='small' margin="dense" disabled={true} multiline inputProps={{style: {fontFamily: 'monospace'}}} />;
-        } else if(columnValue?.toString()?.length > 200){
+          contentColumnValue = (
+            <TextField
+              value={JSON.stringify(columnValue, null, 2)}
+              size='small'
+              margin='dense'
+              disabled={true}
+              multiline
+              inputProps={{ style: { fontFamily: 'monospace' } }}
+            />
+          );
+        } else if (columnValue?.toString()?.length > 200) {
           // greater than a limit, then render as a multiple lines
-           contentColumnValue = <TextField value={columnValue} size='small' margin="dense" disabled={true} multiline/>;
+          contentColumnValue = (
+            <TextField value={columnValue} size='small' margin='dense' disabled={true} multiline />
+          );
         }
 
         return (
           <React.Fragment key={columnName}>
-            <InputLabel sx={{mt: 1, fontWeight:'bold'}}>{columnName}</InputLabel>
+            <InputLabel sx={{ mt: 1, fontWeight: 'bold' }}>{columnName}</InputLabel>
             {contentColumnValue}
           </React.Fragment>
         );


### PR DESCRIPTION
- Better way to render different types of values in the Record Details Page

### Long Text
![image](https://user-images.githubusercontent.com/3792401/176917428-1f4d116d-2f7c-4cd0-8130-6d38d93d6b85.png)

### Nested Objects / Arrays (rendered as JSON blob)
![image](https://user-images.githubusercontent.com/3792401/176917495-eebc9089-232f-4d74-9b7b-4c4dce556c3b.png)

### Raw HTML
![image](https://user-images.githubusercontent.com/3792401/176917675-9cd4f587-06b3-43d1-a764-cefe146a4f82.png)
