### PR TITLE
Edit record page MVP

### DIFF
--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -1,6 +1,11 @@
 import { getDivider } from 'src/common/adapters/BaseDataAdapter/scripts';
 import { SqlAction, SqluiCore } from 'typings';
 
+function _escapeSQLValue(value?: string){
+  value = value || '';
+  return value?.toString().replace(/'/g, `''`)
+}
+
 const formatter = 'sql';
 
 export function getSampleConnectionString(dialect?: SqluiCore.Dialect) {
@@ -158,7 +163,7 @@ export function getInsert(
     .map((col) => {
       if (value?.[col.name]) {
         // use the value if it's there
-        return `'${value[col.name]}'`;
+        return `'${_escapeSQLValue(value[col.name])}'`;
       }
       return `'_${col.name}_'`; // use the default value
     })
@@ -267,8 +272,8 @@ export function getUpdateWithValues(input: SqlAction.TableInput, value: Record<s
     return undefined;
   }
 
-  const columnString = Object.keys(value).map((colName) => `${colName} = '${value[colName] || ""}'`).join(' AND \n');
-  const whereColumnString = Object.keys(conditions).map((colName) => `${colName} = '${conditions[colName] || ""}'`).join(' AND \n');
+  const columnString = Object.keys(value).map((colName) => `${colName} = '${_escapeSQLValue(value[colName])}'`).join(' AND \n');
+  const whereColumnString = Object.keys(conditions).map((colName) => `${colName} = '${_escapeSQLValue(conditions[colName])}'`).join(' AND \n');
 
   switch (input.dialect) {
     case 'mssql':

--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -260,6 +260,32 @@ export function getUpdate(input: SqlAction.TableInput): SqlAction.Output | undef
   }
 }
 
+export function getUpdateWithValues(input: SqlAction.TableInput, value: Record<string, any>, conditions: Record<string, any>): SqlAction.Output | undefined {
+  const label = `Update`;
+
+  if (!input.columns) {
+    return undefined;
+  }
+
+  const columnString = Object.keys(value).map((colName) => `${colName} = '${value[colName] || ""}'`).join(' AND \n');
+  const whereColumnString = Object.keys(conditions).map((colName) => `${colName} = '${conditions[colName] || ""}'`).join(' AND \n');
+
+  switch (input.dialect) {
+    case 'mssql':
+    case 'postgres':
+    case 'sqlite':
+    case 'mariadb':
+    case 'mysql':
+      return {
+        label,
+        formatter: 'js',
+        query: `UPDATE ${input.tableId}
+                SET ${columnString}
+                WHERE ${whereColumnString}`,
+      };
+  }
+}
+
 export function getDelete(input: SqlAction.TableInput): SqlAction.Output | undefined {
   const label = `Delete`;
 

--- a/src/frontend/components/QueryBox/ConnectionDatabaseSelector.tsx
+++ b/src/frontend/components/QueryBox/ConnectionDatabaseSelector.tsx
@@ -8,6 +8,8 @@ type ConnectionDatabaseSelectorProps = {
   value: Partial<SqluiFrontend.ConnectionQuery>;
   onChange: (connectionId?: string, databaseId?: string, tableId?: string) => void;
   isTableIdRequired?: boolean;
+  disabledConnection?: boolean;
+  disabledDatabase?: boolean;
 };
 
 export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSelectorProps) {
@@ -58,7 +60,7 @@ export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSele
         (connection) => connection.id === query.connectionId,
       );
       return getIsTableIdRequiredForQuery(selectedConnection?.dialect);
-    }, [connections, query.connectionId]) || !!props.isTableIdRequired;
+    }, [connections, query.connectionId]) || !!props.isTableIdRequired || true;
 
   if (isLoading) {
     <>
@@ -84,11 +86,12 @@ export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSele
       <Select
         value={query.connectionId}
         onChange={(newValue) => onConnectionChange(newValue)}
-        required>
+        required
+        disabled={!!props.disabledConnection}>
         <option value=''>Pick a Connection</option>
         {connectionOptions}
       </Select>
-      <Select value={query.databaseId} onChange={(newValue) => onDatabaseChange(newValue)}>
+      <Select value={query.databaseId} onChange={(newValue) => onDatabaseChange(newValue)} disabled={!!props.disabledDatabase}>
         <option value=''>Pick a Database (Optional)</option>
         {databaseOptions}
       </Select>
@@ -101,3 +104,4 @@ export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSele
     </>
   );
 }
+

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -66,7 +66,7 @@ type RecordFormReponse = {
  */
 function RecordView(props: RecordDetailsPageProps) {
   const { data } = props;
-  const columnNames = Object.keys(data || {});
+  const columnNames = Object.keys(data || {}).sort();
 
   return (
     <>
@@ -223,7 +223,7 @@ function RecordForm(props) {
       </React.Fragment>,
     );
   } else if (columns && columns.length > 0) {
-    for (const column of columns) {
+    for (const column of columns.sort((a,b) => a.name.localeCompare(b.name))) {
       const baseInputProps: TextFieldProps = {
         label: `${column.name} (${column.type.toLowerCase()}) ${
           column.primaryKey ? '(Primary Key)' : ''

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -22,7 +22,8 @@ import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import LayoutTwoColumns from 'src/frontend/layout/LayoutTwoColumns';
 import { formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
-
+import { useActionDialogs } from 'src/frontend/hooks/useActionDialogs';
+import useToaster from 'src/frontend/hooks/useToaster';
 type RecordData = any;
 
 type RecordFormProps = {
@@ -303,6 +304,7 @@ export function NewRecordPage() {
   const { value: width, onChange: onSetWidth } = useSideBarWidthPreference();
   const { setTreeActions } = useTreeActions();
   const { onAddQuery } = useConnectionQueries();
+  const { add: addToast } = useToaster();
 
   const onSave = async ({ query, connection, columns, data }) => {
     let sql: string = '';
@@ -337,7 +339,13 @@ export function NewRecordPage() {
       ...query,
       sql,
     });
+
     navigate('/');
+
+
+    await addToast({
+      message: `New Record Query attached, please review and execute the query manually...`,
+    });
   };
 
   const onCancel = () => {
@@ -383,7 +391,9 @@ export function EditRecordPage(props: RecordDetailsPageProps) {
   const { onAddQuery } = useConnectionQueries();
   const [isEdit, setIsEdit] = useState(false);
   const { query: activeQuery } = useActiveConnectionQuery();
-    const { data: connection } = useGetConnectionById(activeQuery?.connectionId);
+  const { data: connection } = useGetConnectionById(activeQuery?.connectionId);
+  const { dismiss } = useActionDialogs();
+  const { add: addToast } = useToaster();
   // TODO: intelligently pick up the table name from schema of data
 
   const onSave = async ({ query, connection, columns, data, deltaFields }) => {
@@ -445,15 +455,19 @@ export function EditRecordPage(props: RecordDetailsPageProps) {
       //   break;
     }
 
-    console.log(sql)
 
-    // onAddQuery({
-    //   name: `New Record Query - ${new Date().toLocaleDateString()}`,
-    //   ...query,
-    //   sql,
-    // });
+    onAddQuery({
+      name: `New Record Query - ${new Date().toLocaleDateString()}`,
+      ...query,
+      sql,
+    });
 
-    // TODO: close modal
+    await addToast({
+      message: `Edit Record Query attached, please review and execute the query manually...`,
+    });
+
+    // close modal
+    dismiss();
   };
 
   const onCancel = () => {


### PR DESCRIPTION
#315

- Implement the MVP for edit record page
- Now properly escape SQL values (aka `'` for these insert / update queries with values)
- For more context, we will always show the `table` names in the `ConnectionDatabaseSelector` component

### Edit Record Page
![image](https://user-images.githubusercontent.com/3792401/176939743-4bc17731-469a-4e4a-8c7e-dad3bbdf1202.png)
![image](https://user-images.githubusercontent.com/3792401/176939785-bf70b7f8-68f6-4af5-853a-cfcec2c20a96.png)
![image](https://user-images.githubusercontent.com/3792401/176939820-5595e5fc-eae8-4170-ad2b-032d3409c40d.png)
![image](https://user-images.githubusercontent.com/3792401/176939835-2d1ef8b3-1db5-4527-b0da-f3f99d59483e.png)
![image](https://user-images.githubusercontent.com/3792401/176939849-97a7f908-af7d-47ff-807d-e866e5b9d550.png)