### PR TITLE
Now also reveal table as part of the connection reveal action

### DIFF
--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -227,7 +227,7 @@ export default function MissionControl() {
     if (databaseId && connectionId) {
       branchesToReveal.push([connectionId, databaseId].join(' > '));
 
-      if(tableId){
+      if (tableId) {
         branchesToReveal.push([connectionId, databaseId, tableId].join(' > '));
       }
     }

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -216,7 +216,7 @@ export default function MissionControl() {
   };
 
   const onRevealQueryConnection = async (query: SqluiFrontend.ConnectionQuery) => {
-    const { databaseId, connectionId } = query;
+    const { databaseId, connectionId, tableId } = query;
 
     if (!connectionId) {
       return;
@@ -226,6 +226,10 @@ export default function MissionControl() {
 
     if (databaseId && connectionId) {
       branchesToReveal.push([connectionId, databaseId].join(' > '));
+
+      if(tableId){
+        branchesToReveal.push([connectionId, databaseId, tableId].join(' > '));
+      }
     }
 
     for (const branchToReveal of branchesToReveal) {


### PR DESCRIPTION
Before this change, only Connection and Database are revealed. If tableId is present, it doesn't reveal it.
- Now also reveal table as part of the connection reveal action. 