### PR TITLE
Minor updates to Column Expand and Highlight State

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.41.1",
+  "version": "1.42.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/frontend/components/ColumnDescription/index.tsx
+++ b/src/frontend/components/ColumnDescription/index.tsx
@@ -19,7 +19,6 @@ type ColumnDescriptionProps = {
 };
 
 export default function ColumnDescription(props: ColumnDescriptionProps) {
-  const [showAllColumns, setShowAllColumns] = useState(false);
   const { databaseId, connectionId, tableId } = props;
   const {
     data: columns,
@@ -27,6 +26,13 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
     isError,
   } = useGetColumns(connectionId, databaseId, tableId);
   const { visibles, onToggle } = useShowHide();
+  const keyShowAllColumns = [connectionId, databaseId, tableId, '__ShowAllColumns__'].join(' > ');
+  const [showAllColumns, setShowAllColumns] = useState(visibles[keyShowAllColumns]);
+
+  const onShowAllColumns = () => {
+    setShowAllColumns(true)
+    onToggle(keyShowAllColumns, true);
+  }
 
   useEffect(() => {
     if (columns && columns.length <= MAX_COLUMN_SIZE_TO_SHOW) {
@@ -76,7 +82,7 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
         })}
       {!showAllColumns && (
         <div className='ShowAllColumnsButton'>
-          <Button onClick={() => setShowAllColumns(true)}>Show All Columns</Button>
+          <Button onClick={() => onShowAllColumns()}>Show All Columns</Button>
         </div>
       )}
     </>

--- a/src/frontend/components/ColumnDescription/index.tsx
+++ b/src/frontend/components/ColumnDescription/index.tsx
@@ -1,5 +1,6 @@
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import React, { useEffect, useState } from 'react';
@@ -9,6 +10,7 @@ import ColumnName from 'src/frontend/components/ColumnDescription/ColumnName';
 import ColumnType from 'src/frontend/components/ColumnDescription/ColumnType';
 import { useGetColumns } from 'src/frontend/hooks/useConnection';
 import { useShowHide } from 'src/frontend/hooks/useShowHide';
+import { useActiveConnectionQuery } from 'src/frontend/hooks/useConnectionQuery';
 
 const MAX_COLUMN_SIZE_TO_SHOW = 5;
 
@@ -20,6 +22,7 @@ type ColumnDescriptionProps = {
 
 export default function ColumnDescription(props: ColumnDescriptionProps) {
   const { databaseId, connectionId, tableId } = props;
+  const { query: activeQuery } = useActiveConnectionQuery();
   const {
     data: columns,
     isLoading: loadingColumns,
@@ -64,15 +67,16 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
         .filter((column, idx) => showAllColumns || idx <= MAX_COLUMN_SIZE_TO_SHOW)
         .map((column) => {
           const key = [connectionId, databaseId, tableId, column.name].join(' > ');
+          const isSelected = visibles[key];
           return (
             <React.Fragment key={column.name}>
               <AccordionHeader
                 expanded={visibles[key]}
                 onToggle={() => onToggle(key)}
-                className='ColumnDescription'>
+                className={isSelected ? 'selected ColumnDescription' : 'ColumnDescription'}>
                 <ViewColumnIcon color='disabled' fontSize='inherit' />
-                <ColumnName value={column.name}></ColumnName>
-                <ColumnType value={column.type}></ColumnType>
+                  <ColumnName value={column.name}></ColumnName>
+                  <ColumnType value={column.type}></ColumnType>
               </AccordionHeader>
               <AccordionBody expanded={visibles[key]}>
                 <ColumnAttributes column={column} />

--- a/src/frontend/components/ColumnDescription/index.tsx
+++ b/src/frontend/components/ColumnDescription/index.tsx
@@ -1,6 +1,5 @@
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import React, { useEffect, useState } from 'react';
@@ -9,8 +8,8 @@ import ColumnAttributes from 'src/frontend/components/ColumnDescription/ColumnAt
 import ColumnName from 'src/frontend/components/ColumnDescription/ColumnName';
 import ColumnType from 'src/frontend/components/ColumnDescription/ColumnType';
 import { useGetColumns } from 'src/frontend/hooks/useConnection';
-import { useShowHide } from 'src/frontend/hooks/useShowHide';
 import { useActiveConnectionQuery } from 'src/frontend/hooks/useConnectionQuery';
+import { useShowHide } from 'src/frontend/hooks/useShowHide';
 
 const MAX_COLUMN_SIZE_TO_SHOW = 5;
 
@@ -33,9 +32,9 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
   const [showAllColumns, setShowAllColumns] = useState(visibles[keyShowAllColumns]);
 
   const onShowAllColumns = () => {
-    setShowAllColumns(true)
+    setShowAllColumns(true);
     onToggle(keyShowAllColumns, true);
-  }
+  };
 
   useEffect(() => {
     if (columns && columns.length <= MAX_COLUMN_SIZE_TO_SHOW) {
@@ -75,8 +74,8 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
                 onToggle={() => onToggle(key)}
                 className={isSelected ? 'selected ColumnDescription' : 'ColumnDescription'}>
                 <ViewColumnIcon color='disabled' fontSize='inherit' />
-                  <ColumnName value={column.name}></ColumnName>
-                  <ColumnType value={column.type}></ColumnType>
+                <ColumnName value={column.name}></ColumnName>
+                <ColumnType value={column.type}></ColumnType>
               </AccordionHeader>
               <AccordionBody expanded={visibles[key]}>
                 <ColumnAttributes column={column} />


### PR DESCRIPTION
- Sync the show all column state of `ColumnDescription` as part of the tree state
- Add a gentle highlight state for the expanded table.

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/176970352-81794fd5-ef63-4bed-b146-35de5b897a02.png)
