### PR TITLE
Added a dedicated action menu for inline connection / database / table selector

### DIFF
--- a/src/frontend/components/QueryBox/index.tsx
+++ b/src/frontend/components/QueryBox/index.tsx
@@ -26,10 +26,87 @@ import { useConnectionQuery } from 'src/frontend/hooks/useConnectionQuery';
 import useToaster from 'src/frontend/hooks/useToaster';
 import { formatDuration, formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore } from 'typings';
+import DropdownButton from 'src/frontend/components/DropdownButton';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import {
+  getIsTableIdRequiredForQuery,
+  getTableActions,
+} from 'src/common/adapters/DataScriptFactory';
+import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
+import { useGetColumns } from 'src/frontend/hooks/useConnection';
 
 type QueryBoxProps = {
   queryId: string;
 };
+
+type ConnectionActionsButtonProps= {
+  query: SqluiCore.ConnectionQuery
+}
+
+function ConnectionActionsButton(props: ConnectionActionsButtonProps){
+  const {query} = props;
+  const  {databaseId, connectionId, tableId} = query;
+  const [open, setOpen] = useState(false);
+  const querySize = useQuerySizeSetting();
+
+  const { selectCommand } = useCommands();
+
+  const { data: connection, isLoading: loadingConnection } = useGetConnectionById(connectionId);
+  const { data: columns, isLoading: loadingColumns } = useGetColumns(
+    connectionId,
+    databaseId,
+    tableId,
+  );
+
+  const dialect = connection?.dialect;
+
+  const isLoading = loadingConnection || loadingColumns;
+
+  const isTableIdRequiredForQuery = getIsTableIdRequiredForQuery(dialect);
+
+  const actions = getTableActions({
+    dialect,
+    connectionId,
+    databaseId,
+    tableId,
+    columns: columns || [],
+    querySize,
+  });
+
+  const options = actions.map((action) => ({
+    label: action.label,
+    startIcon: action.icon,
+    onClick: async () =>
+      action.query &&
+      selectCommand({
+        event: 'clientEvent/query/apply',
+        data: {
+          connectionId,
+          databaseId,
+          tableId: tableId,
+          sql: action.query,
+        },
+        label: `Applied "${action.label}" to active query tab.`,
+      }),
+  }));
+
+
+  if(!databaseId || !connectionId || !tableId){
+    return null
+  }
+
+  return <DropdownButton
+          id='session-action-split-button'
+          options={options}
+          onToggle={(newOpen) => setOpen(newOpen)}
+          isLoading={isLoading}
+          maxHeight='400px'>
+          <IconButton aria-label='Table Actions' color='inherit'>
+            <MenuIcon fontSize='inherit' color='inherit' />
+          </IconButton>
+        </DropdownButton>
+}
 
 export default function QueryBox(props: QueryBoxProps) {
   const { queryId } = props;
@@ -171,6 +248,7 @@ export default function QueryBox(props: QueryBoxProps) {
         <div className='FormInput__Row'>
           <ConnectionDatabaseSelector value={query} onChange={onDatabaseConnectionChange} />
           <ConnectionRevealButton query={query} />
+          <ConnectionActionsButton query={query} />
         </div>
         <CodeEditorBox
           value={query.sql}

--- a/src/frontend/components/QueryBox/index.tsx
+++ b/src/frontend/components/QueryBox/index.tsx
@@ -2,17 +2,24 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 import BackupIcon from '@mui/icons-material/Backup';
 import FormatColorTextIcon from '@mui/icons-material/FormatColorText';
 import HelpIcon from '@mui/icons-material/Help';
+import MenuIcon from '@mui/icons-material/Menu';
 import SendIcon from '@mui/icons-material/Send';
 import { Button } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { getSyntaxModeByDialect } from 'src/common/adapters/DataScriptFactory';
+import {
+  getIsTableIdRequiredForQuery,
+  getSyntaxModeByDialect,
+  getTableActions,
+} from 'src/common/adapters/DataScriptFactory';
 import CodeEditorBox, { EditorRef } from 'src/frontend/components/CodeEditorBox';
+import DropdownButton from 'src/frontend/components/DropdownButton';
 import { useCommands } from 'src/frontend/components/MissionControl';
 import ConnectionDatabaseSelector from 'src/frontend/components/QueryBox/ConnectionDatabaseSelector';
 import ConnectionRevealButton from 'src/frontend/components/QueryBox/ConnectionRevealButton';
@@ -20,33 +27,26 @@ import ResultBox from 'src/frontend/components/ResultBox';
 import {
   refreshAfterExecution,
   useExecute,
+  useGetColumns,
   useGetConnectionById,
 } from 'src/frontend/hooks/useConnection';
 import { useConnectionQuery } from 'src/frontend/hooks/useConnectionQuery';
+import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
 import useToaster from 'src/frontend/hooks/useToaster';
 import { formatDuration, formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore } from 'typings';
-import DropdownButton from 'src/frontend/components/DropdownButton';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import {
-  getIsTableIdRequiredForQuery,
-  getTableActions,
-} from 'src/common/adapters/DataScriptFactory';
-import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
-import { useGetColumns } from 'src/frontend/hooks/useConnection';
 
 type QueryBoxProps = {
   queryId: string;
 };
 
-type ConnectionActionsButtonProps= {
-  query: SqluiCore.ConnectionQuery
-}
+type ConnectionActionsButtonProps = {
+  query: SqluiCore.ConnectionQuery;
+};
 
-function ConnectionActionsButton(props: ConnectionActionsButtonProps){
-  const {query} = props;
-  const  {databaseId, connectionId, tableId} = query;
+function ConnectionActionsButton(props: ConnectionActionsButtonProps) {
+  const { query } = props;
+  const { databaseId, connectionId, tableId } = query;
   const [open, setOpen] = useState(false);
   const querySize = useQuerySizeSetting();
 
@@ -90,22 +90,22 @@ function ConnectionActionsButton(props: ConnectionActionsButtonProps){
         label: `Applied "${action.label}" to active query tab.`,
       }),
   }));
-
-
-  if(!databaseId || !connectionId || !tableId){
-    return null
+  if (!databaseId || !connectionId || !tableId) {
+    return null;
   }
 
-  return <DropdownButton
-          id='session-action-split-button'
-          options={options}
-          onToggle={(newOpen) => setOpen(newOpen)}
-          isLoading={isLoading}
-          maxHeight='400px'>
-          <IconButton aria-label='Table Actions' color='inherit'>
-            <MenuIcon fontSize='inherit' color='inherit' />
-          </IconButton>
-        </DropdownButton>
+  return (
+    <DropdownButton
+      id='session-action-split-button'
+      options={options}
+      onToggle={(newOpen) => setOpen(newOpen)}
+      isLoading={isLoading}
+      maxHeight='400px'>
+      <IconButton aria-label='Table Actions' color='inherit'>
+        <MenuIcon fontSize='inherit' color='inherit' />
+      </IconButton>
+    </DropdownButton>
+  );
 }
 
 export default function QueryBox(props: QueryBoxProps) {


### PR DESCRIPTION
This will make it easier to find suggested query based on the metadata of the current query.
- Added a dedicated action menu for inline connection / database / table selector
![image](https://user-images.githubusercontent.com/3792401/177012262-b241d3b3-d3a5-45be-9f9d-2f479c2cda5b.png)
