### PR TITLE
Ability to undo to insert the connection and queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.42.7",
+  "version": "1.43.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -132,6 +132,21 @@ export default function MissionControl() {
   const onCloseQuery = async (query: SqluiFrontend.ConnectionQuery) => {
     try {
       await confirm(`Do you want to delete this query "${query.name}"?`);
+
+      const onUndo = async () => {
+        curToast?.dismiss();
+        await connectionQueries.onAddQuery(query);
+      }
+
+      let curToast = await addToast({
+        message: <>
+          Query {query.name} closed.
+          <Button size="small" onClick={onUndo} sx={{ml: 'auto'}}>
+            UNDO
+          </Button>
+        </>,
+      });
+
       await connectionQueries.onDeleteQueries([query.id]);
     } catch (err) {}
   };
@@ -470,9 +485,9 @@ export default function MissionControl() {
       await confirm('Delete this connection?');
       await deleteConnection(connection.id);
 
-      const onUndo = () => {
+      const onUndo = async () => {
         curToast?.dismiss();
-        duplicateConnection(connection);
+        await duplicateConnection(connection);
       }
 
       curToast = await addToast({

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -2,6 +2,7 @@ import AddIcon from '@mui/icons-material/Add';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import Link from '@mui/material/Link';
+import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { useQuery, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
@@ -468,8 +469,19 @@ export default function MissionControl() {
     try {
       await confirm('Delete this connection?');
       await deleteConnection(connection.id);
+
+      const onUndo = () => {
+        curToast?.dismiss();
+        duplicateConnection(connection);
+      }
+
       curToast = await addToast({
-        message: `Connection "${connection.name}" deleted`,
+        message: <>
+          Connection {connection.name} deleted.
+          <Button size="small" onClick={onUndo} sx={{ml: 'auto'}}>
+            UNDO
+          </Button>
+        </>,
       });
 
       createSystemNotification(

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -133,15 +133,15 @@ export default function MissionControl() {
     try {
       await confirm(`Do you want to delete this query "${query.name}"?`);
 
-      const onUndo = async () => {
+      const onUndoConnection = async () => {
         curToast?.dismiss();
-        await connectionQueries.onAddQuery(query);
+        await connectionQueries.onAddQuery({...query});
       }
 
-      let curToast = await addToast({
+      const curToast = await addToast({
         message: <>
-          Query {query.name} closed.
-          <Button size="small" onClick={onUndo} sx={{ml: 'auto'}}>
+          Query "{query.name}" closed.
+          <Button size="small" onClick={onUndoConnection} sx={{ml: 'auto'}}>
             UNDO
           </Button>
         </>,
@@ -154,8 +154,25 @@ export default function MissionControl() {
   const onCloseOtherQueries = async (query: SqluiFrontend.ConnectionQuery) => {
     try {
       await confirm(`Do you want to close other queries except "${query.name}"?`);
+
+      const queriesToClose = queries?.filter((q) => q.id !== query.id) || [];
+
+      const onUndoQueries = async () => {
+        curToast?.dismiss();
+        await connectionQueries.onAddQueries(queriesToClose);
+      }
+
+      const curToast = await addToast({
+        message: <>
+          Multiple queries closed.
+          <Button size="small" onClick={onUndoQueries} sx={{ml: 'auto'}}>
+            UNDO
+          </Button>
+        </>,
+      });
+
       await connectionQueries.onDeleteQueries(
-        queries?.map((q) => q.id).filter((queryId) => queryId !== query.id),
+        queriesToClose?.map((q) => q.id),
       );
     } catch (err) {}
   };
@@ -168,15 +185,35 @@ export default function MissionControl() {
       await confirm(`Do you want to close all the queries to the right of "${query.name}"?`);
 
       // find the target idx
+      let targetIdx : number = -1;
       for (let i = 0; i < queries.length; i++) {
         if (queries[i].id === query.id) {
-          const targetIdx = i;
-          await connectionQueries.onDeleteQueries(
-            queries.filter((_q, idx) => idx > targetIdx).map((q) => q.id),
-          );
-          await connectionQueries.onShowQuery(query.id);
+          targetIdx = i;
           break;
         }
+      }
+
+      if(targetIdx >= 0){
+        const queriesToClose = queries.filter((_q, idx) => idx > targetIdx);
+
+        const onUndoQueries = async () => {
+          curToast?.dismiss();
+          await connectionQueries.onAddQueries(queriesToClose);
+        }
+
+        const curToast = await addToast({
+          message: <>
+            Multiple queries closed.
+            <Button size="small" onClick={onUndoQueries} sx={{ml: 'auto'}}>
+              UNDO
+            </Button>
+          </>,
+        });
+
+        await connectionQueries.onDeleteQueries(
+          queriesToClose.map((q) => q.id),
+        );
+        await connectionQueries.onShowQuery(query.id);
       }
     } catch (err) {}
   };
@@ -485,15 +522,15 @@ export default function MissionControl() {
       await confirm('Delete this connection?');
       await deleteConnection(connection.id);
 
-      const onUndo = async () => {
+      const onUndoConnection = async () => {
         curToast?.dismiss();
         await duplicateConnection(connection);
       }
 
       curToast = await addToast({
         message: <>
-          Connection {connection.name} deleted.
-          <Button size="small" onClick={onUndo} sx={{ml: 'auto'}}>
+          Connection "{connection.name}" deleted.
+          <Button size="small" onClick={onUndoConnection} sx={{ml: 'auto'}}>
             UNDO
           </Button>
         </>,

--- a/src/frontend/components/Toast/index.tsx
+++ b/src/frontend/components/Toast/index.tsx
@@ -2,11 +2,13 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import Slide from '@mui/material/Slide';
 import Snackbar from '@mui/material/Snackbar';
+import Box from '@mui/material/Box';
+import React from 'react';
 
 type ToastProps = {
   open: boolean;
   onClose: () => void;
-  message: string;
+  message: string | React.ReactElement;
   autoHideDuration?: number;
   anchorOrigin?: AnchorOrigin;
 };
@@ -32,6 +34,10 @@ export default function Toast(props: ToastProps) {
   const vertical = anchorOrigin?.vertical || 'bottom';
   const horizontal = anchorOrigin?.horizontal || 'center';
 
+  const messageDom = <Box sx={{display: 'flex', alignItems: 'center', width: '350px'}}>
+    {message}
+  </Box>
+
   return (
     <Snackbar
       open={open}
@@ -41,7 +47,7 @@ export default function Toast(props: ToastProps) {
       }}
       autoHideDuration={autoHideDuration}
       onClose={onClose}
-      message={message}
+      message={messageDom}
       action={action}
       TransitionComponent={Slide}
     />

--- a/src/frontend/hooks/useToaster.tsx
+++ b/src/frontend/hooks/useToaster.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import Toast, { AnchorOrigin } from 'src/frontend/components/Toast';
 import { getGeneratedRandomId } from 'src/frontend/utils/commonUtils';
@@ -6,7 +7,7 @@ const QUERY_KEY_TOASTS = 'toasts';
 
 type CoreToasterProps = {
   onClose?: () => void;
-  message: string;
+  message: string | React.ReactElement;
   anchorOrigin?: AnchorOrigin;
   autoHideDuration?: number;
 };


### PR DESCRIPTION
#439 

- When we close a connection or query, we should show a toast with the ability to undo that changes.
- Refactor onAddQuery to support adding multiple queries at once

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/177826557-0dd20760-0b8d-4302-ad26-781caba87695.png)
![image](https://user-images.githubusercontent.com/3792401/177830046-6ad6a46b-d069-4fdd-9b75-e8731b82007e.png)

