### PR TITLE
Consolidate sorting of the names of databases, tables and columns inside of the base data adapter.

### DIFF
--- a/src/common/Endpoints.ts
+++ b/src/common/Endpoints.ts
@@ -1,11 +1,11 @@
 import { Express } from 'express';
 import {
+  getColumns,
   getConnectionMetaData,
   getDataAdapter,
-  resetConnectionMetaData,
-  getColumns,
+  getDatabases,
   getTables,
-  getDatabases
+  resetConnectionMetaData,
 } from 'src/common/adapters/DataAdapterFactory';
 import PersistentStorage from 'src/common/PersistentStorage';
 import { SqluiCore, SqluiEnums } from 'typings';
@@ -138,34 +138,40 @@ export function setUpDataEndpoints(anExpressAppContext?: Express) {
   });
 
   addDataEndpoint('get', '/api/connection/:connectionId/databases', async (req, res, apiCache) => {
-    res.status(200).json(await getDatabases(
-        req.headers['sqlui-native-session-id'],
-        req.params?.connectionId
-      )
-    );
+    res
+      .status(200)
+      .json(await getDatabases(req.headers['sqlui-native-session-id'], req.params?.connectionId));
   });
 
   addDataEndpoint(
     'get',
     '/api/connection/:connectionId/database/:databaseId/tables',
-    async (req, res) => res.status(200).json(await getTables(
-          req.headers['sqlui-native-session-id'],
-          req.params?.connectionId,
-          req.params?.databaseId
-        )
-      ),
+    async (req, res) =>
+      res
+        .status(200)
+        .json(
+          await getTables(
+            req.headers['sqlui-native-session-id'],
+            req.params?.connectionId,
+            req.params?.databaseId,
+          ),
+        ),
   );
 
   addDataEndpoint(
     'get',
     '/api/connection/:connectionId/database/:databaseId/table/:tableId/columns',
-    async (req, res) => res.status(200).json(await getColumns(
-          req.headers['sqlui-native-session-id'],
-          req.params?.connectionId,
-          req.params?.databaseId,
-          req.params?.tableId
-        )
-      ),
+    async (req, res) =>
+      res
+        .status(200)
+        .json(
+          await getColumns(
+            req.headers['sqlui-native-session-id'],
+            req.params?.connectionId,
+            req.params?.databaseId,
+            req.params?.tableId,
+          ),
+        ),
   );
 
   addDataEndpoint('post', '/api/connection/:connectionId/connect', async (req, res, apiCache) => {

--- a/src/common/adapters/BaseDataAdapter/index.ts
+++ b/src/common/adapters/BaseDataAdapter/index.ts
@@ -99,6 +99,6 @@ export default abstract class BaseDataAdapter {
       };
     }
 
-    return Object.values(columnsMap).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    return Object.values(columnsMap);
   }
 }

--- a/src/common/adapters/CassandraDataAdapter/index.ts
+++ b/src/common/adapters/CassandraDataAdapter/index.ts
@@ -85,8 +85,7 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
       .map((keyspace) => ({
         name: keyspace,
         tables: [],
-      }))
-      .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      }));
   }
 
   async getTables(database?: string): Promise<SqluiCore.TableMetaData[]> {
@@ -115,8 +114,7 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
       .map((row) => ({
         name: row.name,
         columns: [],
-      }))
-      .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      }));
   }
 
   async getColumns(table: string, database?: string): Promise<SqluiCore.ColumnMetaData[]> {
@@ -143,7 +141,6 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
     const res = await this._execute(sql, [database, table]);
 
     return res.rows
-      .sort((a: any, b: any) => (a.name || '').localeCompare(b.name || ''))
       .map((row) => ({
         name: row.name,
         type: row.type,

--- a/src/common/adapters/CassandraDataAdapter/index.ts
+++ b/src/common/adapters/CassandraDataAdapter/index.ts
@@ -81,11 +81,10 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
 
     //@ts-ignore
     const keyspaces = Object.keys(client?.metadata?.keyspaces);
-    return keyspaces
-      .map((keyspace) => ({
-        name: keyspace,
-        tables: [],
-      }));
+    return keyspaces.map((keyspace) => ({
+      name: keyspace,
+      tables: [],
+    }));
   }
 
   async getTables(database?: string): Promise<SqluiCore.TableMetaData[]> {
@@ -110,11 +109,10 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
 
     const res = await this._execute(sql, [database]);
 
-    return res.rows
-      .map((row) => ({
-        name: row.name,
-        columns: [],
-      }));
+    return res.rows.map((row) => ({
+      name: row.name,
+      columns: [],
+    }));
   }
 
   async getColumns(table: string, database?: string): Promise<SqluiCore.ColumnMetaData[]> {
@@ -140,12 +138,11 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
     }
     const res = await this._execute(sql, [database, table]);
 
-    return res.rows
-      .map((row) => ({
-        name: row.name,
-        type: row.type,
-        kind: row.kind,
-      }));
+    return res.rows.map((row) => ({
+      name: row.name,
+      type: row.type,
+      kind: row.kind,
+    }));
   }
 
   private async _execute(sql: string, params?: string[], database?: string) {

--- a/src/common/adapters/DataAdapterFactory.ts
+++ b/src/common/adapters/DataAdapterFactory.ts
@@ -139,18 +139,22 @@ export async function getColumns(sessionId: string, connectionId: string, databa
   ).get(connectionId);
 
   return (await getDataAdapter(connection.connection).getColumns(tableId, databaseId)).sort((a, b) => {
-          if (a.primaryKey !== b.primaryKey) {
-            if (a.primaryKey) {
-              return -1;
-            }
-            return 1;
+      const aPrimaryKey = a.primaryKey || a.kind === 'partition_key';
+      const bPrimaryKey = b.primaryKey || b.kind === 'partition_key';
+
+          if (aPrimaryKey !== bPrimaryKey) {
+            return aPrimaryKey ? -1: 1;
           }
 
           if (a.unique !== b.unique) {
-            if (a.unique) {
-              return -1;
-            }
-            return 1;
+            return a.unique ? -1: 1;
+          }
+
+          const aClusterKey = a.kind === 'clustering';
+      const bClusterKey = b.kind === 'clustering';
+
+      if (aClusterKey !== bClusterKey) {
+            return aClusterKey ? -1: 1;
           }
 
           return (a.name || '').localeCompare(b.name || '');

--- a/src/common/adapters/DataAdapterFactory.ts
+++ b/src/common/adapters/DataAdapterFactory.ts
@@ -7,6 +7,7 @@ import MongoDBDataAdapter from 'src/common/adapters/MongoDBDataAdapter/index';
 import RedisDataAdapter from 'src/common/adapters/RedisDataAdapter/index';
 import RelationalDataAdapter from 'src/common/adapters/RelationalDataAdapter/index';
 import { SqluiCore } from 'typings';
+import PersistentStorage from 'src/common/PersistentStorage';
 
 const _adapterCache: { [index: string]: IDataAdapter } = {};
 
@@ -111,4 +112,31 @@ export function resetConnectionMetaData(connection: SqluiCore.CoreConnectionProp
   delete _adapterCache[connection.connection];
 
   return connItem;
+}
+
+export async function getDatabases(sessionId: string, connectionId: string){
+  const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
+    sessionId,
+    'connection',
+  ).get(connectionId);
+
+  return getDataAdapter(connection.connection).getDatabases();
+}
+
+export async function getTables(sessionId: string, connectionId: string, databaseId: string){
+  const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
+    sessionId,
+    'connection',
+  ).get(connectionId);
+
+  return getDataAdapter(connection.connection).getTables(databaseId);
+}
+
+export async function getColumns(sessionId: string, connectionId: string, databaseId: string, tableId:string){
+  const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
+    sessionId,
+    'connection',
+  ).get(connectionId);
+
+  return getDataAdapter(connection.connection).getColumns(tableId, databaseId);
 }

--- a/src/common/adapters/DataAdapterFactory.ts
+++ b/src/common/adapters/DataAdapterFactory.ts
@@ -6,8 +6,8 @@ import IDataAdapter from 'src/common/adapters/IDataAdapter';
 import MongoDBDataAdapter from 'src/common/adapters/MongoDBDataAdapter/index';
 import RedisDataAdapter from 'src/common/adapters/RedisDataAdapter/index';
 import RelationalDataAdapter from 'src/common/adapters/RelationalDataAdapter/index';
-import { SqluiCore } from 'typings';
 import PersistentStorage from 'src/common/PersistentStorage';
+import { SqluiCore } from 'typings';
 
 const _adapterCache: { [index: string]: IDataAdapter } = {};
 
@@ -114,49 +114,60 @@ export function resetConnectionMetaData(connection: SqluiCore.CoreConnectionProp
   return connItem;
 }
 
-export async function getDatabases(sessionId: string, connectionId: string){
+export async function getDatabases(sessionId: string, connectionId: string) {
   const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
     sessionId,
     'connection',
   ).get(connectionId);
 
-  return (await getDataAdapter(connection.connection).getDatabases()).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  return (await getDataAdapter(connection.connection).getDatabases()).sort((a, b) =>
+    (a.name || '').localeCompare(b.name || ''),
+  );
 }
 
-export async function getTables(sessionId: string, connectionId: string, databaseId: string){
+export async function getTables(sessionId: string, connectionId: string, databaseId: string) {
   const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
     sessionId,
     'connection',
   ).get(connectionId);
 
-  return (await getDataAdapter(connection.connection).getTables(databaseId)).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  return (await getDataAdapter(connection.connection).getTables(databaseId)).sort((a, b) =>
+    (a.name || '').localeCompare(b.name || ''),
+  );
 }
 
-export async function getColumns(sessionId: string, connectionId: string, databaseId: string, tableId:string){
+export async function getColumns(
+  sessionId: string,
+  connectionId: string,
+  databaseId: string,
+  tableId: string,
+) {
   const connection = await new PersistentStorage<SqluiCore.ConnectionProps>(
     sessionId,
     'connection',
   ).get(connectionId);
 
-  return (await getDataAdapter(connection.connection).getColumns(tableId, databaseId)).sort((a, b) => {
+  return (await getDataAdapter(connection.connection).getColumns(tableId, databaseId)).sort(
+    (a, b) => {
       const aPrimaryKey = a.primaryKey || a.kind === 'partition_key';
       const bPrimaryKey = b.primaryKey || b.kind === 'partition_key';
 
-          if (aPrimaryKey !== bPrimaryKey) {
-            return aPrimaryKey ? -1: 1;
-          }
+      if (aPrimaryKey !== bPrimaryKey) {
+        return aPrimaryKey ? -1 : 1;
+      }
 
-          if (a.unique !== b.unique) {
-            return a.unique ? -1: 1;
-          }
+      if (a.unique !== b.unique) {
+        return a.unique ? -1 : 1;
+      }
 
-          const aClusterKey = a.kind === 'clustering';
+      const aClusterKey = a.kind === 'clustering';
       const bClusterKey = b.kind === 'clustering';
 
       if (aClusterKey !== bClusterKey) {
-            return aClusterKey ? -1: 1;
-          }
+        return aClusterKey ? -1 : 1;
+      }
 
-          return (a.name || '').localeCompare(b.name || '');
-        });
+      return (a.name || '').localeCompare(b.name || '');
+    },
+  );
 }

--- a/src/common/adapters/DataAdapterFactory.ts
+++ b/src/common/adapters/DataAdapterFactory.ts
@@ -120,7 +120,7 @@ export async function getDatabases(sessionId: string, connectionId: string){
     'connection',
   ).get(connectionId);
 
-  return getDataAdapter(connection.connection).getDatabases();
+  return (await getDataAdapter(connection.connection).getDatabases()).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 }
 
 export async function getTables(sessionId: string, connectionId: string, databaseId: string){
@@ -129,7 +129,7 @@ export async function getTables(sessionId: string, connectionId: string, databas
     'connection',
   ).get(connectionId);
 
-  return getDataAdapter(connection.connection).getTables(databaseId);
+  return (await getDataAdapter(connection.connection).getTables(databaseId)).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 }
 
 export async function getColumns(sessionId: string, connectionId: string, databaseId: string, tableId:string){
@@ -138,5 +138,21 @@ export async function getColumns(sessionId: string, connectionId: string, databa
     'connection',
   ).get(connectionId);
 
-  return getDataAdapter(connection.connection).getColumns(tableId, databaseId);
+  return (await getDataAdapter(connection.connection).getColumns(tableId, databaseId)).sort((a, b) => {
+          if (a.primaryKey !== b.primaryKey) {
+            if (a.primaryKey) {
+              return -1;
+            }
+            return 1;
+          }
+
+          if (a.unique !== b.unique) {
+            if (a.unique) {
+              return -1;
+            }
+            return 1;
+          }
+
+          return (a.name || '').localeCompare(b.name || '');
+        });
 }

--- a/src/common/adapters/MongoDBDataAdapter/index.ts
+++ b/src/common/adapters/MongoDBDataAdapter/index.ts
@@ -58,11 +58,10 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
     try {
       //@ts-ignore
       const res = await client.db().admin().listDatabases();
-      return res.databases
-        .map((database: any) => ({
-          name: database.name,
-          tables: [],
-        }));
+      return res.databases.map((database: any) => ({
+        name: database.name,
+        tables: [],
+      }));
     } finally {
       this.closeConnection(client);
     }
@@ -75,11 +74,10 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
       //@ts-ignore
       const collections = await client.db(database).listCollections().toArray();
 
-      return (collections || [])
-        .map((collection) => ({
-          name: collection.name,
-          columns: [],
-        }));
+      return (collections || []).map((collection) => ({
+        name: collection.name,
+        columns: [],
+      }));
     } finally {
       this.closeConnection(client);
     }

--- a/src/common/adapters/MongoDBDataAdapter/index.ts
+++ b/src/common/adapters/MongoDBDataAdapter/index.ts
@@ -62,8 +62,7 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
         .map((database: any) => ({
           name: database.name,
           tables: [],
-        }))
-        .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        }));
     } finally {
       this.closeConnection(client);
     }
@@ -80,8 +79,7 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
         .map((collection) => ({
           name: collection.name,
           columns: [],
-        }))
-        .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        }));
     } finally {
       this.closeConnection(client);
     }

--- a/src/common/adapters/RelationalDataAdapter/index.ts
+++ b/src/common/adapters/RelationalDataAdapter/index.ts
@@ -201,23 +201,7 @@ export default class RelationalDataAdapter extends BaseDataAdapter implements ID
           }
         } catch (err) {}
 
-        return columns.sort((a, b) => {
-          if (a.primaryKey !== b.primaryKey) {
-            if (a.primaryKey) {
-              return -1;
-            }
-            return 1;
-          }
-
-          if (a.unique !== b.unique) {
-            if (a.unique) {
-              return -1;
-            }
-            return 1;
-          }
-
-          return (a.name || '').localeCompare(b.name || '');
-        });
+        return columns;
     }
   }
 


### PR DESCRIPTION
- Consolidate sorting of the names of databases, tables and columns inside of the base data adapter.
- No longer doing sorting at each of the adapter level.