### PR TITLE
Cleaned up getUpdatedOrdersForList and add more tests

### DIFF
--- a/src/frontend/utils/commonUtils.spec.tsx
+++ b/src/frontend/utils/commonUtils.spec.tsx
@@ -76,54 +76,59 @@ FROM
   });
 
   describe('getUpdatedOrdersForList', () => {
-    const items = [11, 22, 33, 44, 55];
+    let items;
+
+    beforeEach(() => {
+      items = [11, 22, 33, 44, 55]
+    })
+
     test('should work for from=4, to=2', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 2);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 2);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,55,33,44"`);
     });
 
     test('should work for from=4, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 3);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 3);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,55,44"`);
     });
 
     test('should work for from=4, to=0', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 0);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 0);
       expect(actual.join(',')).toMatchInlineSnapshot(`"55,11,22,33,44"`);
     });
 
     test('should work for from=0, to=1', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 1);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 1);
       expect(actual.join(',')).toMatchInlineSnapshot(`"22,11,33,44,55"`);
     });
 
     test('should work for from=0, to=4', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 4);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 4);
       expect(actual.join(',')).toMatchInlineSnapshot(`"22,33,44,55,11"`);
     });
 
     test('should work for from=0, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 3);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 3);
       expect(actual.join(',')).toMatchInlineSnapshot(`"22,33,44,11,55"`);
     });
 
     test('should work for from=1, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 1, 3);
+      let actual = commonUtils.getUpdatedOrdersForList(items, 1, 3);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,33,44,22,55"`);
     });
 
     test('should work for from=0, to=0 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 0)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 0)
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
 
     test('should work for from=3, to=3 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 3, 3)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 3, 3)
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
 
     test('should work for from=4, to=4 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 4)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 4)
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
   });

--- a/src/frontend/utils/commonUtils.spec.tsx
+++ b/src/frontend/utils/commonUtils.spec.tsx
@@ -79,8 +79,8 @@ FROM
     let items;
 
     beforeEach(() => {
-      items = [11, 22, 33, 44, 55]
-    })
+      items = [11, 22, 33, 44, 55];
+    });
 
     test('should work for from=4, to=2', async () => {
       let actual = commonUtils.getUpdatedOrdersForList(items, 4, 2);
@@ -118,17 +118,17 @@ FROM
     });
 
     test('should work for from=0, to=0 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 0)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 0);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
 
     test('should work for from=3, to=3 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 3, 3)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 3, 3);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
 
     test('should work for from=4, to=4 (no change in order)', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 4)
+      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 4);
       expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
   });

--- a/src/frontend/utils/commonUtils.spec.tsx
+++ b/src/frontend/utils/commonUtils.spec.tsx
@@ -78,38 +78,53 @@ FROM
   describe('getUpdatedOrdersForList', () => {
     const items = [11, 22, 33, 44, 55];
     test('should work for from=4, to=2', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 2);
-      expect(actual).toStrictEqual([11, 22, 55, 33, 44]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 2);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,55,33,44"`);
     });
 
     test('should work for from=4, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 3);
-      expect(actual).toStrictEqual([11, 22, 33, 55, 44]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 3);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,55,44"`);
     });
 
     test('should work for from=4, to=0', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 4, 0);
-      expect(actual).toStrictEqual([55, 11, 22, 33, 44]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 0);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"55,11,22,33,44"`);
     });
 
     test('should work for from=0, to=1', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 1);
-      expect(actual).toStrictEqual([22, 11, 33, 44, 55]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 1);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"22,11,33,44,55"`);
     });
 
     test('should work for from=0, to=4', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 4);
-      expect(actual).toStrictEqual([22, 33, 44, 55, 11]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 4);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"22,33,44,55,11"`);
     });
 
     test('should work for from=0, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 0, 3);
-      expect(actual).toStrictEqual([22, 33, 44, 11, 55]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 3);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"22,33,44,11,55"`);
     });
 
     test('should work for from=1, to=3', async () => {
-      let actual = commonUtils.getUpdatedOrdersForList(items, 1, 3);
-      expect(actual).toStrictEqual([11, 33, 44, 22, 55]);
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 1, 3);
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,33,44,22,55"`);
+    });
+
+    test('should work for from=0, to=0 (no change in order)', async () => {
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 0, 0)
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
+    });
+
+    test('should work for from=3, to=3 (no change in order)', async () => {
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 3, 3)
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
+    });
+
+    test('should work for from=4, to=4 (no change in order)', async () => {
+      let actual = commonUtils.getUpdatedOrdersForList([...items], 4, 4)
+      expect(actual.join(',')).toMatchInlineSnapshot(`"11,22,33,44,55"`);
     });
   });
 });

--- a/src/frontend/utils/commonUtils.tsx
+++ b/src/frontend/utils/commonUtils.tsx
@@ -10,22 +10,26 @@ export function getExportedQuery(query: SqluiFrontend.ConnectionQuery) {
   return { _type: 'query', ...{ id, name, sql, connectionId, databaseId } };
 }
 // misc utils
+const TO_BE_DELETED_LIST_ITEM = Symbol('to_be_deleted_list_item');
 export function getUpdatedOrdersForList(items: any[], from: number, to: number) {
-  // ordering will move the tab from the old index to the new index
-  // and push everything from that point out
-  const targetItem = items[from];
-  let leftHalf: SqluiFrontend.ConnectionQuery[];
-  let rightHalf: SqluiFrontend.ConnectionQuery[];
-
-  if (from > to) {
-    leftHalf = items.filter((q, idx) => idx < to && idx !== from);
-    rightHalf = items.filter((q, idx) => idx >= to && idx !== from);
-  } else {
-    leftHalf = items.filter((q, idx) => idx <= to && idx !== from);
-    rightHalf = items.filter((q, idx) => idx > to && idx !== from);
+  if(from === to){
+    return items;
   }
 
-  return [...leftHalf, targetItem, ...rightHalf];
+  const targetItem = items[from];
+  items[from] = TO_BE_DELETED_LIST_ITEM;
+
+  // from > to : this is where we insert before `to`
+  // from < to : this is where we insert after `to`
+  items.splice(
+    from > to
+     ? to
+     : to + 1,
+     0,
+     targetItem
+   );
+
+  return items.filter(item => item !== TO_BE_DELETED_LIST_ITEM)
 }
 
 export function getGeneratedRandomId(prefix: string) {

--- a/src/frontend/utils/commonUtils.tsx
+++ b/src/frontend/utils/commonUtils.tsx
@@ -11,8 +11,9 @@ export function getExportedQuery(query: SqluiFrontend.ConnectionQuery) {
 }
 // misc utils
 const TO_BE_DELETED_LIST_ITEM = Symbol('to_be_deleted_list_item');
+
 export function getUpdatedOrdersForList(items: any[], from: number, to: number) {
-  if(from === to){
+  if (from === to) {
     return items;
   }
 
@@ -21,15 +22,9 @@ export function getUpdatedOrdersForList(items: any[], from: number, to: number) 
 
   // from > to : this is where we insert before `to`
   // from < to : this is where we insert after `to`
-  items.splice(
-    from > to
-     ? to
-     : to + 1,
-     0,
-     targetItem
-   );
+  items.splice(from > to ? to : to + 1, 0, targetItem);
 
-  return items.filter(item => item !== TO_BE_DELETED_LIST_ITEM)
+  return items.filter((item) => item !== TO_BE_DELETED_LIST_ITEM);
 }
 
 export function getGeneratedRandomId(prefix: string) {


### PR DESCRIPTION
- Cleaned up `getUpdatedOrdersForList` to use `splice` and now do sorting changes inline with splice and no longer requires cloning the existing object.
- Added unit tests for when `from` and `to` are the same, the order should not change.