### PR TITLE
Can't render array of primitives properly inside of the table

### DIFF
--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -30,6 +30,8 @@ export const ALL_PAGE_SIZE_OPTIONS: any[] = [
 
 export const DEFAULT_TABLE_PAGE_SIZE = 50;
 
+const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
+
 function TableContainerWrapper(props: any) {
   return (
     <Paper square={true} variant='outlined' sx={{ overflow: 'auto' }}>
@@ -200,11 +202,20 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
 
   const columns = useMemo(() => {
     const newColumnNames = new Set<string>();
-    for (const row of data) {
-      for (const header of Object.keys(row)) {
-        newColumnNames.add(header);
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      if(typeof row === 'object'){
+        // is an object, then render as a list of properties
+        for (const header of Object.keys(row)) {
+          newColumnNames.add(header);
+        }
+      } else {
+        // otherwise, render it as a column named `unknown`
+        newColumnNames.add(UNNAMED_PROPERTY_NAME);
+        data[i] = {UNNAMED_PROPERTY_NAME: row}
       }
     }
+
     return Array.from(newColumnNames).map((columnName) => {
       return {
         Header: columnName,

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -204,7 +204,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
     const newColumnNames = new Set<string>();
     for (let i = 0; i < data.length; i++) {
       const row = data[i];
-      if(typeof row === 'object'){
+      if (typeof row === 'object') {
         // is an object, then render as a list of properties
         for (const header of Object.keys(row)) {
           newColumnNames.add(header);
@@ -212,7 +212,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
       } else {
         // otherwise, render it as a column named `unknown`
         newColumnNames.add(UNNAMED_PROPERTY_NAME);
-        data[i] = {UNNAMED_PROPERTY_NAME: row}
+        data[i] = { UNNAMED_PROPERTY_NAME: row };
       }
     }
 


### PR DESCRIPTION
Fixes #470

- Can't render array of primitives properly inside of the table

### Sample query to generate this behavior
Use any one of the select distinct inside of MongoDB

```js
db.collection('sy-collection-1a')
  .distinct(
    'location', {
    }
  )
```

### Issue
#### Raw JSON input
This is the raw JSON that causes this issue
```
[
  "",
  "Bay Area",
  "Morgan Hill",
  "San Jose, CA",
  "sdfgdsf"
]
```

#### Bug
![image](https://user-images.githubusercontent.com/3792401/178131639-6997ab53-356b-4253-b201-5058798b231b.png)


### Expected
Will render the column for these primitives as standalone

![image](https://user-images.githubusercontent.com/3792401/178131706-af9f7fd8-02c4-4d4d-98f9-2803e2838471.png)
