### PR TITLE
MongoDB doesn't render findOne nicely

### DIFF
--- a/src/common/adapters/MongoDBDataAdapter/index.ts
+++ b/src/common/adapters/MongoDBDataAdapter/index.ts
@@ -171,7 +171,7 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
           meta: rawToUse,
           affectedRows,
         };
-      } else if (Array.isArray(rawToUse) || (typeof rawToUse === 'object' && rawToUse._id) ) {
+      } else if (Array.isArray(rawToUse) || (typeof rawToUse === 'object' && rawToUse._id)) {
         return {
           ok: true,
           raw: [].concat(rawToUse),

--- a/src/common/adapters/MongoDBDataAdapter/index.ts
+++ b/src/common/adapters/MongoDBDataAdapter/index.ts
@@ -171,15 +171,15 @@ export default class MongoDBDataAdapter extends BaseDataAdapter implements IData
           meta: rawToUse,
           affectedRows,
         };
-      } else if (Array.isArray(rawToUse)) {
+      } else if (Array.isArray(rawToUse) || (typeof rawToUse === 'object' && rawToUse._id) ) {
         return {
           ok: true,
-          raw: rawToUse,
+          raw: [].concat(rawToUse),
         };
       } else {
         return {
           ok: true,
-          raw: rawToUse,
+          meta: rawToUse,
         };
       }
     } catch (err: any) {


### PR DESCRIPTION
Fixes #472

- MongoDB doesn't render `findOne` nicely
- It does render, but it shows up as a raw JSON object, will be nice to render it as a table row.

### Issue
![image](https://user-images.githubusercontent.com/3792401/178131922-25a6ac27-cda7-4bf4-8718-8b89224a38a1.png)

### Expected
Should render it in the table format
![image](https://user-images.githubusercontent.com/3792401/178131908-461f3d00-a5f9-4feb-8f4e-2d12e541f403.png)
