### PR TITLE
Azure Table Migration Script MVP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.46.4",
+  "version": "1.47.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/common/adapters/AzureTableStorageAdapter/index.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/index.ts
@@ -187,7 +187,7 @@ export default class AzureTableStorageAdapter extends BaseDataAdapter implements
       }
     } catch (error: any) {
       console.log(error);
-      return { ok: false, error: JSON.stringify(error, null, 2) };
+      return { ok: false, error: error.toString() };
     } finally {
       this.closeConnection();
     }

--- a/src/common/adapters/AzureTableStorageAdapter/scripts.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/scripts.ts
@@ -106,7 +106,7 @@ export function getBulkInsert(
   input: SqlAction.TableInput,
   rows?: Record<string, any>[],
   rowKeyField?: string,
-  partitionKeyField?: string
+  partitionKeyField?: string,
 ): SqlAction.Output | undefined {
   const label = `Insert`;
 
@@ -119,12 +119,10 @@ export function getBulkInsert(
   }
 
   // TODO: will create the UI for users to hook up row key and partition key
-
-
   // find out the primary key
-  if(!rowKeyField){
-    for(const column of input.columns){
-      if(column.primaryKey || column.kind === 'partition_key'){
+  if (!rowKeyField) {
+    for (const column of input.columns) {
+      if (column.primaryKey || column.kind === 'partition_key') {
         // here is where we infer the rowKey for our record
         rowKeyField = column.name;
         break;
@@ -132,18 +130,20 @@ export function getBulkInsert(
     }
   }
 
-  rows = rows.map(row => ({
+  rows = rows.map((row) => ({
     ...row,
     rowKey: rowKeyField ? row[rowKeyField]?.toString() : '<your_row_key>',
     partitionKey: rowKeyField ? row[rowKeyField]?.toString() : '<your_partition_key>',
-  }))
+  }));
 
   return {
     label,
     formatter,
     query: `
       Promise.all([
-        ${rows.map(row => `${AZTABLE_TABLE_CLIENT_PREFIX}.createEntity(${JSON.stringify(row)})`).join(',')}
+        ${rows
+          .map((row) => `${AZTABLE_TABLE_CLIENT_PREFIX}.createEntity(${JSON.stringify(row)})`)
+          .join(',')}
       ])
     `.trim(),
   };
@@ -160,8 +160,6 @@ export function getBulkInsert(
   //   query: `${AZTABLE_TABLE_CLIENT_PREFIX}.submitTransaction(${JSON.stringify(rowsActions, null, 2)})`,
   // };
 }
-
-
 export function getUpdateWithValues(
   input: SqlAction.TableInput,
   value: Record<string, any>,

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -1,25 +1,22 @@
 import BackupIcon from '@mui/icons-material/Backup';
+import LoadingButton from '@mui/lab/LoadingButton';
 import { Button, Link, Skeleton, TextField, Typography } from '@mui/material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { getBulkInsert as getBulkInsertForAzTable } from 'src/common/adapters/AzureTableStorageAdapter/scripts';
 import { getSampleSelectQuery } from 'src/common/adapters/DataScriptFactory';
 import {
   getBulkInsert as getBulkInsertForRdmbs,
   getCreateTable as getCreateTableForRdbms,
 } from 'src/common/adapters/RelationalDataAdapter/scripts';
-import {
-  getBulkInsert as getBulkInsertForAzTable,
-} from 'src/common/adapters/AzureTableStorageAdapter/scripts';
 import CodeEditorBox from 'src/frontend/components/CodeEditorBox';
 import ConnectionDatabaseSelector from 'src/frontend/components/QueryBox/ConnectionDatabaseSelector';
 import Select from 'src/frontend/components/Select';
 import dataApi from 'src/frontend/data/api';
 import { useGetColumns, useGetConnections } from 'src/frontend/hooks/useConnection';
 import { useConnectionQueries } from 'src/frontend/hooks/useConnectionQuery';
-import { formatSQL, formatJS } from 'src/frontend/utils/formatter';
+import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
-import LoadingButton from '@mui/lab/LoadingButton';
-
 // TOOD: extract this
 type MigrationBoxProps = {
   mode: SqluiFrontend.MigrationMode;


### PR DESCRIPTION
Part of #336 
- Currently we will attempt to figure out the `rowKey` and `partitionKey`. But will add the UI later for the user to select the row key and partition key.

### Notes
- The `New Table Name` doesn't make sense in the context of Azure Table dialect. Will remove.
- Add the UI to select the rowkey and partitionkey.
- There might be an issue with Azure Table concurrency. We will need to adjust the batch size.
- We didn't use the batch API ([submitTransaction](https://docs.microsoft.com/en-us/azure/cosmos-db/table/how-to-use-nodejs#work-with-groups-of-entities)) because it requires the partition key to be same.