### PR TITLE
Extracted Migration MetaData UI into a separate component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",
   "browserslist": {
     "production": [

--- a/src/common/adapters/BaseDataAdapter/index.ts
+++ b/src/common/adapters/BaseDataAdapter/index.ts
@@ -89,7 +89,7 @@ export default abstract class BaseDataAdapter {
     return columnsMap;
   }
 
-  static inferTypesFromItems(items: any): SqluiCore.ColumnMetaData[] {
+  static inferTypesFromItems(items: any[]): SqluiCore.ColumnMetaData[] {
     let columnsMap: Record<string, SqluiCore.ColumnMetaData> = {};
 
     for (const item of items) {

--- a/src/common/adapters/BaseDataAdapter/index.ts
+++ b/src/common/adapters/BaseDataAdapter/index.ts
@@ -48,7 +48,10 @@ export default abstract class BaseDataAdapter {
     return undefined;
   }
 
-  static resolveTypes(inputItem: any, incomingTypeConverter?: (type: string, value: any) => string) {
+  static resolveTypes(
+    inputItem: any,
+    incomingTypeConverter?: (type: string, value: any) => string,
+  ) {
     const stack: {
       item: any;
       path: string[];
@@ -56,11 +59,11 @@ export default abstract class BaseDataAdapter {
     }[] = [{ item: inputItem, path: [], key: '' }];
 
     const onTypeConverter = (type: string, value: any) => {
-      if(incomingTypeConverter){
+      if (incomingTypeConverter) {
         return incomingTypeConverter(type, value);
       }
       return type;
-    }
+    };
 
     const columnsMap: Record<string, SqluiCore.ColumnMetaData> = {};
     const visited = new Set<string>();
@@ -108,28 +111,25 @@ export default abstract class BaseDataAdapter {
 
     return Object.values(columnsMap);
   }
-
-
-
-   static inferSqlTypeFromItems(items: any[]): SqluiCore.ColumnMetaData[] {
+  static inferSqlTypeFromItems(items: any[]): SqluiCore.ColumnMetaData[] {
     let columnsMap: Record<string, SqluiCore.ColumnMetaData> = {};
 
     for (const item of items) {
       columnsMap = {
         ...columnsMap,
         ...BaseDataAdapter.resolveTypes(item, (type: string, val: any) => {
-            switch(type){
-              case 'number':
-                if (val.toString().includes('.')) {
-                  return 'FLOAT';
-                }
-                return 'INTEGER';
-              case 'boolean':
-                return 'BOOLEAN';
-              default:
-                return 'TEXT'
-            }
-          }),
+          switch (type) {
+            case 'number':
+              if (val.toString().includes('.')) {
+                return 'FLOAT';
+              }
+              return 'INTEGER';
+            case 'boolean':
+              return 'BOOLEAN';
+            default:
+              return 'TEXT';
+          }
+        }),
       };
     }
 

--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -186,12 +186,11 @@ export function getBulkInsert(
       const cells = columns
         .map((col) => {
           let valToUse = '';
-          if (row?.[col.name]) {
+          if (row?.[col.name] !== undefined) {
             // use the value if it's there
             valToUse = `'${escapeSQLValue(row[col.name])}'`;
           } else {
-            // use the default value
-            valToUse = `'_${escapeSQLValue(col.name)}_'`;
+            valToUse = 'null';
           }
           return valToUse;
         })
@@ -329,6 +328,12 @@ export function getCreateTable(input: SqlAction.TableInput): SqlAction.Output | 
   }
 
   let columnString: string = '';
+
+  // map the nested column accordingly (using _ as a separator)
+  input.columns = input.columns.map(col => {
+    col.name = col.propertyPath?.join('_') || col.name;
+    return col
+  })
 
   // TODO: figure out how to use the defaultval
   switch (input.dialect) {

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -4,7 +4,9 @@ import { Button, Link, Skeleton, TextField, Typography } from '@mui/material';
 import get from 'lodash.get';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { getBulkInsert as getBulkInsertForAzTable } from 'src/common/adapters/AzureTableStorageAdapter/scripts';
+import { getBulkInsert as getBulkInsertForAzTable,
+ getCreateTable as getCreateTableForAzTable
+ } from 'src/common/adapters/AzureTableStorageAdapter/scripts';
 import BaseDataAdapter from 'src/common/adapters/BaseDataAdapter/index';
 import { getSampleSelectQuery } from 'src/common/adapters/DataScriptFactory';
 import {
@@ -95,7 +97,8 @@ async function generateMigrationScript(
     // case 'redis': // TODO: to be implemented
     // case 'cosmosdb': // TODO: to be implemented
     case 'aztable':
-      res.push(`// Schema Creation Script : N/A for toDialect=${toDialect}`);
+      res.push(`// Schema Creation Script : toDialect=${toDialect} toTableId=${toTableId}`);
+      res.push(formatSQL(getCreateTableForAzTable(toQueryMetaData)?.query || ''));
       break;
   }
 
@@ -502,34 +505,21 @@ function MigrationMetaDataInputs(props: MigrationMetaDataInputsProps) {
     return null;
   }
 
-  let shouldShowNewTableName = true;
-  switch (migrationMetaData.toDialect) {
-    // case 'cassandra': // TODO: to be implemented
-    // case 'mongodb': // TODO: to be implemented
-    // case 'redis': // TODO: to be implemented
-    // case 'cosmosdb': // TODO: to be implemented
-    case 'aztable':
-      shouldShowNewTableName = false;
-      break;
-  }
-
   return (
     <>
       <DialectSelector
         value={migrationMetaData.toDialect}
         onChange={(newToDialect) => onChange('toDialect', newToDialect)}
       />
-      {shouldShowNewTableName && (
-        <TextField
-          label='New Table Name'
-          defaultValue={migrationMetaData.newTableName}
-          onBlur={(e) => onChange('newTableName', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-          autoComplete='off'
-        />
-      )}
+      <TextField
+        label='New Table Name'
+        defaultValue={migrationMetaData.newTableName}
+        onBlur={(e) => onChange('newTableName', e.target.value)}
+        required
+        size='small'
+        fullWidth={true}
+        autoComplete='off'
+      />
     </>
   );
 }

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -4,9 +4,10 @@ import { Button, Link, Skeleton, TextField, Typography } from '@mui/material';
 import get from 'lodash.get';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { getBulkInsert as getBulkInsertForAzTable,
- getCreateTable as getCreateTableForAzTable
- } from 'src/common/adapters/AzureTableStorageAdapter/scripts';
+import {
+  getBulkInsert as getBulkInsertForAzTable,
+  getCreateTable as getCreateTableForAzTable,
+} from 'src/common/adapters/AzureTableStorageAdapter/scripts';
 import BaseDataAdapter from 'src/common/adapters/BaseDataAdapter/index';
 import { getSampleSelectQuery } from 'src/common/adapters/DataScriptFactory';
 import {
@@ -23,10 +24,9 @@ import {
   useGetConnections,
 } from 'src/frontend/hooks/useConnection';
 import { useConnectionQueries } from 'src/frontend/hooks/useConnectionQuery';
+import useToaster from 'src/frontend/hooks/useToaster';
 import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
-import useToaster, { ToasterHandler } from 'src/frontend/hooks/useToaster';
-
 // TOOD: extract this
 type MigrationBoxProps = {
   mode: SqluiFrontend.MigrationMode;
@@ -122,7 +122,9 @@ async function generateMigrationScript(
           res.push(
             `-- The SELECT query does not have any returned that we can use for data migration...`,
           );
-          errors.push(`Warning - This migration doesn't contain any record. This might be an error with your query to get data.`)
+          errors.push(
+            `Warning - This migration doesn't contain any record. This might be an error with your query to get data.`,
+          );
         }
         break;
       // case 'cassandra':// TODO: to be implemented
@@ -137,12 +139,14 @@ async function generateMigrationScript(
           res.push(
             `// The SELECT query does not have any returned that we can use for data migration...`,
           );
-          errors.push(`Warning - This migration doesn't contain any record. This might be an error with your query to get data.`)
+          errors.push(
+            `Warning - This migration doesn't contain any record. This might be an error with your query to get data.`,
+          );
         }
         break;
     }
   } catch (err) {
-    errors.push(`Select query failed. ${JSON.stringify(err)}`)
+    errors.push(`Select query failed. ${JSON.stringify(err)}`);
   }
 
   return [res.join('\n\n'), errors.join('\n\n')];
@@ -302,7 +306,7 @@ export default function MigrationBox(props: MigrationBoxProps) {
       }
       setMigrationScript(newMigrationScript || '');
 
-      if(error){
+      if (error) {
         await addToast({
           message: error,
         });


### PR DESCRIPTION
- Extracted Migration MetaData UI into a separate component. This component will allow custom meta data input. This is going to be the prep work for making the UI to require `rowKey` and `partitionKey` selection used in Azure Table migration or things of that nature
- Now will generate the db creation for aztable
- Now supporting nested properties in raw json migration mode. Consolidate and move the method to infer sql types into the base adapter (`inferSqlTypeFromItems`)
