### PR TITLE
remove constraint name and also show both keys if it makes sense to

### DIFF
--- a/src/common/adapters/RelationalDataAdapter/index.ts
+++ b/src/common/adapters/RelationalDataAdapter/index.ts
@@ -209,7 +209,6 @@ export default class RelationalDataAdapter extends BaseDataAdapter implements ID
             .getForeignKeyReferencesForTable(table)) as any[];
 
           for (const foreignKeyReference of foreignKeyReferences) {
-            const constraintName = foreignKeyReference.constraintName;
             const fromTableName = foreignKeyReference.tableName;
             const fromColumnName = foreignKeyReference.columnName;
             const toTableName = foreignKeyReference.referencedTableName;
@@ -220,7 +219,6 @@ export default class RelationalDataAdapter extends BaseDataAdapter implements ID
 
               if (targetColumn) {
                 targetColumn.kind = 'foreign_key';
-                targetColumn.constraintName = constraintName || `N/A`;
                 targetColumn.referencedTableName = toTableName;
                 targetColumn.referencedColumnName = toColumnName;
               }

--- a/src/frontend/components/ColumnDescription/index.tsx
+++ b/src/frontend/components/ColumnDescription/index.tsx
@@ -71,8 +71,7 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
           const isSelected = visibles[key];
           const shouldShowPrimaryKeyIcon = column.primaryKey || column.kind === 'partition_key';
           const shouldShowSecondaryKeyIcon = column.kind === 'clustering';
-          const shouldShowForeignKeyIcon =
-            !shouldShowPrimaryKeyIcon && column.kind === 'foreign_key';
+          const shouldShowForeignKeyIcon = column.kind === 'foreign_key';
 
           return (
             <React.Fragment key={column.name}>
@@ -97,7 +96,7 @@ export default function ColumnDescription(props: ColumnDescriptionProps) {
                 )}
                 {shouldShowForeignKeyIcon && (
                   <Tooltip
-                    title={`Foreign Key name=${column.constraintName} referencing table=${column.referencedTableName} column=${column.referencedColumnName}`}>
+                    title={`Foreign Key referencing table=${column.referencedTableName} column=${column.referencedColumnName}`}>
                     <i style={{ height: '15px' }}>
                       <KeyIcon fontSize='small' color='secondary' />{' '}
                     </i>

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -75,7 +75,6 @@ export module SqluiCore {
      */
     kind?: ColumnKindCassandra | ColumnKindRmdbs;
     // these applies for foreignkeys information for rdmbs
-    constraintName?: string;
     referencedTableName?: string;
     referencedColumnName?: string;
     [index: string]: any;


### PR DESCRIPTION
Part of #513

- Now we will show both keys at once (primary key and foreign key for column meta data)
- Removed `ConstraintName` as it is not available for all dialects.

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/180095496-11277f9a-7b8e-46dd-929e-00ce36f65fdb.png)
![image](https://user-images.githubusercontent.com/3792401/180095509-0b2db2bc-c244-4e6f-bbdd-77ff05a0c56f.png)
![image](https://user-images.githubusercontent.com/3792401/180095524-c4bfdf07-992a-41fd-a68a-adce34ce627a.png)
![image](https://user-images.githubusercontent.com/3792401/180095537-c449d0ab-e5ba-42e9-a0d9-a3d2bd9a40c2.png)
