### PR TITLE
Consolidated `getSampleSelectQuery` and Fixed issue with database selector autoselect first option

### DIFF
--- a/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
+++ b/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
@@ -418,6 +418,10 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `cosmosdb://AccountEndpoint=some_cosmos_endpoint;AccountKey=some_cosmos_account_key`;
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return getSelectAllColumns(actionInput)?.query;
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
+++ b/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
@@ -420,7 +420,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return getSelectAllColumns(actionInput)?.query;
+    return getSelectAllColumns(actionInput);
   }
 }
 

--- a/src/common/adapters/AzureTableStorageAdapter/scripts.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/scripts.ts
@@ -316,7 +316,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return getSelectAllColumns(actionInput)?.query;
+    return getSelectAllColumns(actionInput);
   }
 }
 

--- a/src/common/adapters/AzureTableStorageAdapter/scripts.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/scripts.ts
@@ -314,6 +314,10 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `aztable://DefaultEndpointsProtocol=https;AccountName=<your_account_name>;AccountKey=<your_account_key>;EndpointSuffix=core.windows.net`;
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return getSelectAllColumns(actionInput)?.query;
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -43,7 +43,7 @@ export default abstract class BaseDataScript implements IDataScript {
   getSampleConnectionString(dialect?: SqluiCore.Dialect) {
     return '';
   }
-  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) : string | undefined{
     return '';
   }
 }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -47,7 +47,7 @@ export default abstract class BaseDataScript implements IDataScript {
     return '';
   }
 
-  getSampleSelectQuery(actionInput: SqlAction.TableInput) : SqlAction.Output | undefined{
+  getSampleSelectQuery(actionInput: SqlAction.TableInput): SqlAction.Output | undefined {
     return undefined;
   }
 }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -34,15 +34,19 @@ export default abstract class BaseDataScript implements IDataScript {
   getTableScripts(): SqlAction.TableActionScriptGenerator[] {
     return [];
   }
+
   getDatabaseScripts(): SqlAction.DatabaseActionScriptGenerator[] {
     return [];
   }
+
   getConnectionScripts(): SqlAction.ConnectionActionScriptGenerator[] {
     return [];
   }
+
   getSampleConnectionString(dialect?: SqluiCore.Dialect) {
     return '';
   }
+
   getSampleSelectQuery(actionInput: SqlAction.TableInput) : SqlAction.Output | undefined{
     return undefined;
   }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -43,4 +43,7 @@ export default abstract class BaseDataScript implements IDataScript {
   getSampleConnectionString(dialect?: SqluiCore.Dialect) {
     return '';
   }
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return '';
+  }
 }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -43,7 +43,7 @@ export default abstract class BaseDataScript implements IDataScript {
   getSampleConnectionString(dialect?: SqluiCore.Dialect) {
     return '';
   }
-  getSampleSelectQuery(actionInput: SqlAction.TableInput) : string | undefined{
-    return '';
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) : SqlAction.Output | undefined{
+    return undefined;
   }
 }

--- a/src/common/adapters/CassandraDataAdapter/scripts.ts
+++ b/src/common/adapters/CassandraDataAdapter/scripts.ts
@@ -401,7 +401,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return getSelectAllColumns(actionInput)?.query;
+    return getSelectAllColumns(actionInput);
   }
 }
 

--- a/src/common/adapters/CassandraDataAdapter/scripts.ts
+++ b/src/common/adapters/CassandraDataAdapter/scripts.ts
@@ -399,6 +399,10 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `cassandra://username:password@localhost:9042`;
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return getSelectAllColumns(actionInput)?.query;
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -9,12 +9,13 @@ import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqlAction, SqluiCore } from 'typings';
 
 function _formatScript(formatter?: string, query?: string){
+  query = query || '' ;
   switch (formatter) {
     case 'sql':
-      return formatSQL(query || '');
+      return formatSQL(query);
       break;
     case 'js':
-      return formatJS(query || '');
+      return formatJS(query);
       break;
   }
 }
@@ -31,7 +32,9 @@ function _formatScripts(
     //@ts-ignore
     const action = fn(actionInput);
     if (action) {
-      action.query = _formatScript(action?.formatter, action?.query);
+      if(action.query){
+        action.query = _formatScript(action?.formatter, action?.query);
+      }
       actions.push(action);
     }
   }

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -7,6 +7,18 @@ import RedisDataAdapterScripts from 'src/common/adapters/RedisDataAdapter/script
 import RelationalDataAdapterScripts from 'src/common/adapters/RelationalDataAdapter/scripts';
 import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqlAction, SqluiCore } from 'typings';
+
+function _formatScript(formatter?: string, query?: string){
+  switch (formatter) {
+    case 'sql':
+      return formatSQL(query || '');
+      break;
+    case 'js':
+      return formatJS(query || '');
+      break;
+  }
+}
+
 function _formatScripts(
   actionInput: SqlAction.TableInput | SqlAction.DatabaseInput | SqlAction.ConnectionInput,
   generatorFuncs:
@@ -19,14 +31,7 @@ function _formatScripts(
     //@ts-ignore
     const action = fn(actionInput);
     if (action) {
-      switch (action.formatter) {
-        case 'sql':
-          action.query = formatSQL(action.query || '');
-          break;
-        case 'js':
-          action.query = formatJS(action.query || '');
-          break;
-      }
+      action.query = _formatScript(action?.formatter, action?.query);
       actions.push(action);
     }
   }
@@ -124,7 +129,8 @@ export function getTableActions(actionInput: SqlAction.TableInput) {
 }
 
 export function getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-  return _formatScripts(_getImplementation(actionInput.dialect)?.getSampleSelectQuery(actionInput));
+  const action = _getImplementation(actionInput.dialect)?.getSampleSelectQuery(actionInput);
+  return _formatScripts(action?.formatter, action?.query);
 }
 
 export function getDatabaseActions(actionInput: SqlAction.DatabaseInput) {

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -130,7 +130,7 @@ export function getTableActions(actionInput: SqlAction.TableInput) {
 
 export function getSampleSelectQuery(actionInput: SqlAction.TableInput) {
   const action = _getImplementation(actionInput.dialect)?.getSampleSelectQuery(actionInput);
-  return _formatScripts(action?.formatter, action?.query);
+  return _formatScript(action?.formatter, action?.query);
 }
 
 export function getDatabaseActions(actionInput: SqlAction.DatabaseInput) {

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -7,9 +7,8 @@ import RedisDataAdapterScripts from 'src/common/adapters/RedisDataAdapter/script
 import RelationalDataAdapterScripts from 'src/common/adapters/RelationalDataAdapter/scripts';
 import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqlAction, SqluiCore } from 'typings';
-
-function _formatScript(formatter?: string, query?: string){
-  query = query || '' ;
+function _formatScript(formatter?: string, query?: string) {
+  query = query || '';
   switch (formatter) {
     case 'sql':
       return formatSQL(query);
@@ -32,7 +31,7 @@ function _formatScripts(
     //@ts-ignore
     const action = fn(actionInput);
     if (action) {
-      if(action.query){
+      if (action.query) {
         action.query = _formatScript(action?.formatter, action?.query);
       }
       actions.push(action);

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -124,11 +124,7 @@ export function getTableActions(actionInput: SqlAction.TableInput) {
 }
 
 export function getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-  const scriptsToUse: SqlAction.TableActionScriptGenerator[] =
-    _getImplementation(actionInput.dialect)?.getTableScripts() || [];
-  return _formatScripts(actionInput, scriptsToUse).filter((script) =>
-    script.label.includes('Select'),
-  )[0];
+  return _formatScripts(_getImplementation(actionInput.dialect)?.getSampleSelectQuery(actionInput));
 }
 
 export function getDatabaseActions(actionInput: SqlAction.DatabaseInput) {

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -15,5 +15,5 @@ export default interface IDataScript {
   getDatabaseScripts: () => SqlAction.DatabaseActionScriptGenerator[];
   getConnectionScripts: () => SqlAction.ConnectionActionScriptGenerator[];
   getSampleConnectionString: (dialect?: SqluiCore.Dialect) => string;
-  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => SqlAction.Output | undefined;
+  getSampleSelectQuery: (actionInput: SqlAction.TableInput) => SqlAction.Output | undefined;
 }

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -15,4 +15,5 @@ export default interface IDataScript {
   getDatabaseScripts: () => SqlAction.DatabaseActionScriptGenerator[];
   getConnectionScripts: () => SqlAction.ConnectionActionScriptGenerator[];
   getSampleConnectionString: (dialect?: SqluiCore.Dialect) => string;
+  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => string;
 }

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -15,5 +15,5 @@ export default interface IDataScript {
   getDatabaseScripts: () => SqlAction.DatabaseActionScriptGenerator[];
   getConnectionScripts: () => SqlAction.ConnectionActionScriptGenerator[];
   getSampleConnectionString: (dialect?: SqluiCore.Dialect) => string;
-  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => string | undefined;
+  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => SqlAction.Output | undefined;
 }

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -15,5 +15,5 @@ export default interface IDataScript {
   getDatabaseScripts: () => SqlAction.DatabaseActionScriptGenerator[];
   getConnectionScripts: () => SqlAction.ConnectionActionScriptGenerator[];
   getSampleConnectionString: (dialect?: SqluiCore.Dialect) => string;
-  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => string;
+  getSampleSelectQuery:(actionInput: SqlAction.TableInput) => string | undefined;
 }

--- a/src/common/adapters/MongoDBDataAdapter/scripts.ts
+++ b/src/common/adapters/MongoDBDataAdapter/scripts.ts
@@ -337,7 +337,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return getSelectAllColumns(actionInput)?.query;
+    return getSelectAllColumns(actionInput);
   }
 }
 

--- a/src/common/adapters/MongoDBDataAdapter/scripts.ts
+++ b/src/common/adapters/MongoDBDataAdapter/scripts.ts
@@ -335,6 +335,10 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `mongodb://localhost:27017`;
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return getSelectAllColumns(actionInput)?.query;
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/RedisDataAdapter/scripts.ts
+++ b/src/common/adapters/RedisDataAdapter/scripts.ts
@@ -270,6 +270,10 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `redis://localhost:6379`;
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return '';
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/RedisDataAdapter/scripts.ts
+++ b/src/common/adapters/RedisDataAdapter/scripts.ts
@@ -272,7 +272,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return '';
+    return undefined;
   }
 }
 

--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -628,7 +628,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return getSelectAllColumns(actionInput)?.query;
+    return getSelectAllColumns(actionInput);
   }
 }
 

--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -626,6 +626,10 @@ export class ConcreteDataScripts extends BaseDataScript {
         return '';
     }
   }
+
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return getSelectAllColumns(actionInput)?.query;
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/_SampleDataAdapter_/scripts.ts
+++ b/src/common/adapters/_SampleDataAdapter_/scripts.ts
@@ -80,7 +80,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   // TODO: implement me
-  getSampleSelectQuery(actionInput: SqlAction.TableInput) : SqlAction.Output | undefined{
+  getSampleSelectQuery(actionInput: SqlAction.TableInput): SqlAction.Output | undefined {
     return undefined;
   }
 }

--- a/src/common/adapters/_SampleDataAdapter_/scripts.ts
+++ b/src/common/adapters/_SampleDataAdapter_/scripts.ts
@@ -78,6 +78,11 @@ export class ConcreteDataScripts extends BaseDataScript {
   getSampleConnectionString(dialect) {
     return `your_dialect://your_props`;
   }
+
+  // TODO: implement me
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
+    return '';
+  }
 }
 
 export default new ConcreteDataScripts();

--- a/src/common/adapters/_SampleDataAdapter_/scripts.ts
+++ b/src/common/adapters/_SampleDataAdapter_/scripts.ts
@@ -80,8 +80,8 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   // TODO: implement me
-  getSampleSelectQuery(actionInput: SqlAction.TableInput) {
-    return '';
+  getSampleSelectQuery(actionInput: SqlAction.TableInput) : SqlAction.Output | undefined{
+    return undefined;
   }
 }
 

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -307,7 +307,7 @@ export default function MigrationBox(props: MigrationBoxProps) {
   const isSaving = migrating;
 
   const isMigrationScriptVisible = !!migrationScript && !!migrationMetaData.toDialect;
-  const isLoading = loadingConnections || loadingConnection;
+  const isLoading = loadingColumns || loadingConnections || loadingConnection;
 
   // effects
   useEffect(() => {

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -307,42 +307,42 @@ export default function MigrationBox(props: MigrationBoxProps) {
   const isSaving = migrating;
 
   const isMigrationScriptVisible = !!migrationScript && !!migrationMetaData.toDialect;
-  const isLoading = loadingColumns || loadingConnections || loadingConnection;
+  const isLoading = loadingConnections || loadingConnection;
 
   // effects
-  // useEffect(() => {
-  //   setSearchParams(
-  //     {
-  //       connectionId: query.connectionId || '',
-  //       databaseId: query.databaseId || '',
-  //       tableId: query.tableId || '',
-  //       toDialect: migrationMetaData.toDialect || 'sqlite',
-  //     },
-  //     { replace: true },
-  //   );
-  // }, [query, migrationMetaData]);
+  useEffect(() => {
+    setSearchParams(
+      {
+        connectionId: query.connectionId || '',
+        databaseId: query.databaseId || '',
+        tableId: query.tableId || '',
+        toDialect: migrationMetaData.toDialect || 'sqlite',
+      },
+      { replace: true },
+    );
+  }, [query, migrationMetaData]);
 
-  // useEffect(() => {
-  //   setQuery({
-  //     ...query,
-  //     connectionId: searchParams.get('connectionId') || '',
-  //     databaseId: searchParams.get('databaseId') || '',
-  //     tableId: searchParams.get('tableId') || '',
-  //   });
+  useEffect(() => {
+    setQuery({
+      ...query,
+      connectionId: searchParams.get('connectionId') || '',
+      databaseId: searchParams.get('databaseId') || '',
+      tableId: searchParams.get('tableId') || '',
+    });
 
-  //   migrationMetaData.toDialect = (searchParams.get('toDialect') as SqluiCore.Dialect) || 'sqlite';
+    migrationMetaData.toDialect = (searchParams.get('toDialect') as SqluiCore.Dialect) || 'sqlite';
 
-  //   setMigrationScript('');
-  // }, []);
+    setMigrationScript('');
+  }, []);
 
-  // useEffect(() => {
-  //   if (query.sql !== migrationMetaData.selectQuery) {
-  //     setQuery({
-  //       ...query,
-  //       sql: migrationMetaData.selectQuery,
-  //     });
-  //   }
-  // }, [query, migrationMetaData.selectQuery]);
+  useEffect(() => {
+    if (query.sql !== migrationMetaData.selectQuery) {
+      setQuery({
+        ...query,
+        sql: migrationMetaData.selectQuery,
+      });
+    }
+  }, [query, migrationMetaData.selectQuery]);
 
   // events
   const onDatabaseConnectionChange = (

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -310,39 +310,39 @@ export default function MigrationBox(props: MigrationBoxProps) {
   const isLoading = loadingColumns || loadingConnections || loadingConnection;
 
   // effects
-  useEffect(() => {
-    setSearchParams(
-      {
-        connectionId: query.connectionId || '',
-        databaseId: query.databaseId || '',
-        tableId: query.tableId || '',
-        toDialect: migrationMetaData.toDialect || 'sqlite',
-      },
-      { replace: true },
-    );
-  }, [query, migrationMetaData]);
+  // useEffect(() => {
+  //   setSearchParams(
+  //     {
+  //       connectionId: query.connectionId || '',
+  //       databaseId: query.databaseId || '',
+  //       tableId: query.tableId || '',
+  //       toDialect: migrationMetaData.toDialect || 'sqlite',
+  //     },
+  //     { replace: true },
+  //   );
+  // }, [query, migrationMetaData]);
 
-  useEffect(() => {
-    setQuery({
-      ...query,
-      connectionId: searchParams.get('connectionId') || '',
-      databaseId: searchParams.get('databaseId') || '',
-      tableId: searchParams.get('tableId') || '',
-    });
+  // useEffect(() => {
+  //   setQuery({
+  //     ...query,
+  //     connectionId: searchParams.get('connectionId') || '',
+  //     databaseId: searchParams.get('databaseId') || '',
+  //     tableId: searchParams.get('tableId') || '',
+  //   });
 
-    migrationMetaData.toDialect = (searchParams.get('toDialect') as SqluiCore.Dialect) || 'sqlite';
+  //   migrationMetaData.toDialect = (searchParams.get('toDialect') as SqluiCore.Dialect) || 'sqlite';
 
-    setMigrationScript('');
-  }, []);
+  //   setMigrationScript('');
+  // }, []);
 
-  useEffect(() => {
-    if (query.sql !== migrationMetaData.selectQuery) {
-      setQuery({
-        ...query,
-        sql: migrationMetaData.selectQuery,
-      });
-    }
-  }, [query, migrationMetaData.selectQuery]);
+  // useEffect(() => {
+  //   if (query.sql !== migrationMetaData.selectQuery) {
+  //     setQuery({
+  //       ...query,
+  //       sql: migrationMetaData.selectQuery,
+  //     });
+  //   }
+  // }, [query, migrationMetaData.selectQuery]);
 
   // events
   const onDatabaseConnectionChange = (

--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -458,15 +458,15 @@ export default function MigrationBox(props: MigrationBoxProps) {
       const fromConnection = connections?.find(
         (connection) => connection.id === query.connectionId,
       );
-      const sampleSelectQuery = getSampleSelectQuery({
+      const sampleSelectQueryText = getSampleSelectQuery({
         ...fromConnection,
         ...query,
         querySize: 50,
       });
-      if (sampleSelectQuery?.query) {
+      if (sampleSelectQueryText) {
         setMigrationMetaData({
           ...migrationMetaData,
-          selectQuery: sampleSelectQuery.query,
+          selectQuery: sampleSelectQueryText,
         });
       }
     }

--- a/src/frontend/components/QueryBox/ConnectionDatabaseSelector.tsx
+++ b/src/frontend/components/QueryBox/ConnectionDatabaseSelector.tsx
@@ -93,13 +93,13 @@ export default function ConnectionDatabaseSelector(props: ConnectionDatabaseSele
     let shouldShowToast = false;
 
     // if there's only one database, then select that as well
-    if (databases && databases.length === 1) {
+    if (databases && databases.length === 1 && databases[0].name !== query.databaseId) {
       onDatabaseChange(databases[0].name);
       shouldShowToast = true;
     }
 
     // if there's only one table, then select that as well
-    if (tables && tables.length === 1) {
+    if (tables && tables.length === 1 && tables[0].name !== query.tableId) {
       onTableChange(tables[0].name);
       shouldShowToast = true;
     }


### PR DESCRIPTION
- Consolidated `getSampleSelectQuery`
- Fixed issue with database selector autoselect first option. Now we check and only do the autoselect changes if the value is different. It causes the data inside of migration selectbox flaky
<img width="971" alt="image" src="https://user-images.githubusercontent.com/3792401/180104439-990aa11b-a5c6-436c-9c0f-9396e40c5f4e.png">
