### PR TITLE
Streamlined builds to also publish packages as part of the workflow artifacts instead of creating a dedicated release

### DIFF
--- a/.github/workflows/dist-beta.yml
+++ b/.github/workflows/dist-beta.yml
@@ -8,43 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  create_release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    outputs:
-      package_version: ${{ steps.package-version.outputs.current-version }}
-      release_upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-          cache: 'yarn'
-      - run: npm version --no-git-tag-version patch
-      - id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-        with:
-          path: '.'
-      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
-        with:
-          delete_release: true
-          tag_name: beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: beta
-          release_name: beta
-          body: |
-            Version: ${{ steps.package-version.outputs.current-version }}
-          draft: false
-          prerelease: true
-
   build_windows:
-    needs: [create_release]
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -59,18 +23,13 @@ jobs:
       - run: yarn build
       - run: yarn dist
       - run: mv ./dist/sqlui-native*.exe ./dist/sqlui-native.exe
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact .exe
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.create_release.outputs.release_upload_url }}
-          asset_path: ./dist/sqlui-native.exe
-          asset_name: sqlui-native-beta.exe
-          asset_content_type: application/octet-stream
+          name: sqlui-native.exe
+          path: ./dist/sqlui-native.exe
 
   build_macos:
-    needs: [create_release]
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -85,18 +44,13 @@ jobs:
       - run: yarn build
       - run: yarn dist
       - run: mv ./dist/sqlui-native*.dmg ./dist/sqlui-native.dmg
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact .dmg
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.create_release.outputs.release_upload_url }}
-          asset_path: ./dist/sqlui-native.dmg
-          asset_name: sqlui-native-beta.dmg
-          asset_content_type: application/octet-stream
+          name: sqlui-native.dmg
+          path: ./dist/sqlui-native.dmg
 
   build_linux:
-    needs: [create_release]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -113,48 +67,18 @@ jobs:
       - run: mv ./dist/sqlui-native*.deb ./dist/sqlui-native.deb
       - run: mv ./dist/sqlui-native*.rpm ./dist/sqlui-native.rpm
       - run: mv ./dist/sqlui-native*.snap ./dist/sqlui-native.snap
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact .deb
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.create_release.outputs.release_upload_url }}
-          asset_path: ./dist/sqlui-native.deb
-          asset_name: sqlui-native-beta.deb
-          asset_content_type: application/octet-stream
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: sqlui-native.deb
+          path: ./dist/sqlui-native.deb
+      - name: Upload artifact .rpm
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.create_release.outputs.release_upload_url }}
-          asset_path: ./dist/sqlui-native.rpm
-          asset_name: sqlui-native-beta.rpm
-          asset_content_type: application/octet-stream
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: sqlui-native.rpm
+          path: ./dist/sqlui-native.rpm
+      - name: Upload artifact .snap
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.create_release.outputs.release_upload_url }}
-          asset_path: ./dist/sqlui-native.snap
-          asset_name: sqlui-native-beta.snap
-          asset_content_type: application/octet-stream
-
-  roll_back_on_failure_or_canceled:
-    if: failure() || cancelled()
-    needs: [create_release, build_windows, build_macos, build_linux]
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-          cache: 'yarn'
-      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
-        with:
-          delete_release: true
-          tag_name: '${{ needs.create_release.outputs.package_version }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: sqlui-native.snap
+          path: ./dist/sqlui-native.snap

--- a/.github/workflows/dist-main.yml
+++ b/.github/workflows/dist-main.yml
@@ -62,7 +62,8 @@ jobs:
       - run: yarn dist
       - run: mv ./dist/sqlui-native*.exe ./dist/sqlui-native.exe
 
-      - uses: actions/upload-release-asset@v1
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -70,6 +71,12 @@ jobs:
           asset_path: ./dist/sqlui-native.exe
           asset_name: sqlui-native-${{ needs.create_release.outputs.package_version }}.exe
           asset_content_type: application/octet-stream
+
+      - name: Upload artifact .exe
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlui-native.exe
+          path: ./dist/sqlui-native.exe
 
   build_macos:
     needs: [create_release]
@@ -88,7 +95,8 @@ jobs:
       - run: yarn dist
       - run: mv ./dist/sqlui-native*.dmg ./dist/sqlui-native.dmg
 
-      - uses: actions/upload-release-asset@v1
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -96,6 +104,12 @@ jobs:
           asset_path: ./dist/sqlui-native.dmg
           asset_name: sqlui-native-${{ needs.create_release.outputs.package_version }}.dmg
           asset_content_type: application/octet-stream
+
+      - name: Upload artifact .dmg
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlui-native.dmg
+          path: ./dist/sqlui-native.dmg
 
   build_linux:
     needs: [create_release]
@@ -116,7 +130,8 @@ jobs:
       - run: mv ./dist/sqlui-native*.rpm ./dist/sqlui-native.rpm
       - run: mv ./dist/sqlui-native*.snap ./dist/sqlui-native.snap
 
-      - uses: actions/upload-release-asset@v1
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -125,7 +140,8 @@ jobs:
           asset_name: sqlui-native-${{ needs.create_release.outputs.package_version }}.deb
           asset_content_type: application/octet-stream
 
-      - uses: actions/upload-release-asset@v1
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -134,7 +150,8 @@ jobs:
           asset_name: sqlui-native-${{ needs.create_release.outputs.package_version }}.rpm
           asset_content_type: application/octet-stream
 
-      - uses: actions/upload-release-asset@v1
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -142,6 +159,22 @@ jobs:
           asset_path: ./dist/sqlui-native.snap
           asset_name: sqlui-native-${{ needs.create_release.outputs.package_version }}.snap
           asset_content_type: application/octet-stream
+
+      - name: Upload artifact .deb
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlui-native.deb
+          path: ./dist/sqlui-native.deb
+      - name: Upload artifact .rpm
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlui-native.rpm
+          path: ./dist/sqlui-native.rpm
+      - name: Upload artifact .snap
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlui-native.snap
+          path: ./dist/sqlui-native.snap
 
   publish:
     needs: [create_release, build_windows, build_macos, build_linux]


### PR DESCRIPTION
- Streamlined builds to also publish packages as part of the workflow artifacts instead of creating a dedicated release
 
### Before
- Beta build will create a release for its own.

### Now
- No longer publish a release for beta build, beta binaries will be uploaded as part of the workflow action.
- Now we will also upload release to workflow artifact as part of the build.

#### Screenshots
![image](https://user-images.githubusercontent.com/3792401/180486310-27f6d387-ffcf-4edf-b4ba-6477254d538a.png)
