### PR TITLE
Tab header minors tweaks - case aware (no longer do labels all caps)

### DIFF
--- a/src/frontend/App.scss
+++ b/src/frontend/App.scss
@@ -123,10 +123,8 @@ $ConnectionTreeIndentSize: 7px;
     &__Header {
       display: inline-flex;
       align-items: center;
-
-      *:last-child {
-        margin-left: 10px;
-      }
+      text-transform: none;
+      gap: 0.5rem;
     }
     &__Body {
       padding-block: 15px;

--- a/src/frontend/components/InputError/index.tsx
+++ b/src/frontend/components/InputError/index.tsx
@@ -22,6 +22,7 @@ export default function InputError(props: InputErrorProps) {
         margin: 0,
         position: 'absolute',
         borderColor: 'transparent',
+        background: 'transparent',
         outline: 'none',
         transform: 'scale(0.2)',
       }}


### PR DESCRIPTION
- Change query tab headers to be case aware (no longer do labels all caps).
- Use `gap` instead of `margin` for layout of tabHeader.
- Fixed `InputError` to no longer show a small pixel. It's not transparent

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/180607077-e2bdfe55-b18f-4930-a1b4-06dda46333aa.png)


![image](https://user-images.githubusercontent.com/3792401/180607064-406a22e9-84be-42ac-87cb-8c88f75b2866.png)
