### PR TITLE
Fixed export query to include `tableId` as part of the exported metadata

### DIFF
--- a/src/frontend/utils/commonUtils.spec.tsx
+++ b/src/frontend/utils/commonUtils.spec.tsx
@@ -22,23 +22,24 @@ describe('commonUtils', () => {
   describe('getExportedQuery', () => {
     test('should work with minimal inputs', async () => {
       const actual = commonUtils.getExportedQuery({
-        id: 'query.1643737746323.6184509846791006',
+        id: 'some_query_id',
         name: 'Query 2/1/2022, 9:49:06 AM',
         sql: 'SELECT\n  TOP 200 *\nFROM\n  albums',
-        connectionId: 'connection.1644098335891.8887562323718656',
-        databaseId: 'musicstores',
+        connectionId: 'some_connection_id',
+        databaseId: 'some_database_id',
       });
       expect(actual).toMatchInlineSnapshot(`
 Object {
   "_type": "query",
-  "connectionId": "connection.1644098335891.8887562323718656",
-  "databaseId": "musicstores",
-  "id": "query.1643737746323.6184509846791006",
+  "connectionId": "some_connection_id",
+  "databaseId": "some_database_id",
+  "id": "some_query_id",
   "name": "Query 2/1/2022, 9:49:06 AM",
   "sql": "SELECT
   TOP 200 *
 FROM
   albums",
+  "tableId": undefined,
 }
 `);
     });
@@ -46,12 +47,12 @@ FROM
     test('should work with more completed data inputs', async () => {
       //@ts-ignore
       const actual = commonUtils.getExportedQuery({
-        id: 'query.1643737746323.6184509846791006',
+        id: 'some_query_id',
         name: 'Query 2/1/2022, 9:49:06 AM',
         sql: 'SELECT\n  TOP 200 *\nFROM\n  albums',
-        connectionId: 'connection.1644098335891.8887562323718656',
+        connectionId: 'some_connection_id',
         selected: true,
-        databaseId: 'musicstores',
+        databaseId: 'some_database_id',
         executionStart: 123,
         executionEnd: 456,
         result: {
@@ -62,14 +63,40 @@ FROM
       expect(actual).toMatchInlineSnapshot(`
 Object {
   "_type": "query",
-  "connectionId": "connection.1644098335891.8887562323718656",
-  "databaseId": "musicstores",
-  "id": "query.1643737746323.6184509846791006",
+  "connectionId": "some_connection_id",
+  "databaseId": "some_database_id",
+  "id": "some_query_id",
   "name": "Query 2/1/2022, 9:49:06 AM",
   "sql": "SELECT
   TOP 200 *
 FROM
   albums",
+  "tableId": undefined,
+}
+`);
+    });
+
+    test('should also include tableId', async () => {
+      const actual = commonUtils.getExportedQuery({
+        id: 'some_query_id',
+        name: 'Query 2/1/2022, 9:49:06 AM',
+        sql: 'SELECT\n  TOP 200 *\nFROM\n  albums',
+        connectionId: 'some_connection_id',
+        databaseId: 'some_database_id',
+        tableId: 'some_table_id',
+      });
+      expect(actual).toMatchInlineSnapshot(`
+Object {
+  "_type": "query",
+  "connectionId": "some_connection_id",
+  "databaseId": "some_database_id",
+  "id": "some_query_id",
+  "name": "Query 2/1/2022, 9:49:06 AM",
+  "sql": "SELECT
+  TOP 200 *
+FROM
+  albums",
+  "tableId": "some_table_id",
 }
 `);
     });

--- a/src/frontend/utils/commonUtils.tsx
+++ b/src/frontend/utils/commonUtils.tsx
@@ -1,4 +1,5 @@
 import { SqluiCore, SqluiFrontend } from 'typings';
+
 // for exporting
 export function getExportedConnection(connectionProps: SqluiCore.ConnectionProps) {
   const { id, connection, name } = connectionProps;
@@ -6,9 +7,10 @@ export function getExportedConnection(connectionProps: SqluiCore.ConnectionProps
 }
 
 export function getExportedQuery(query: SqluiFrontend.ConnectionQuery) {
-  const { id, name, sql, connectionId, databaseId } = query;
-  return { _type: 'query', ...{ id, name, sql, connectionId, databaseId } };
+  const { id, name, sql, connectionId, databaseId, tableId } = query;
+  return { _type: 'query', ...{ id, name, sql, connectionId, databaseId, tableId } };
 }
+
 // misc utils
 const TO_BE_DELETED_LIST_ITEM = Symbol('to_be_deleted_list_item');
 

--- a/src/frontend/utils/commonUtils.tsx
+++ b/src/frontend/utils/commonUtils.tsx
@@ -1,5 +1,4 @@
 import { SqluiCore, SqluiFrontend } from 'typings';
-
 // for exporting
 export function getExportedConnection(connectionProps: SqluiCore.ConnectionProps) {
   const { id, connection, name } = connectionProps;


### PR DESCRIPTION
- Fixed export query to include `tableId` as part of the exported metadata.
