### PR TITLE
Reveal location storage in an explorer when clicking on the link

### DIFF
--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -934,7 +934,6 @@ export default function MissionControl() {
     const onRevealDataLocation = () => {
       const platform = window?.process?.platform;
       const storageDir = serverConfigs?.storageDir || '';
-      let shouldCopyToClipboard = true;
 
       if (!storageDir) {
         return;

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -42,13 +42,10 @@ import {
   getExportedConnection,
   getExportedQuery,
 } from 'src/frontend/utils/commonUtils';
-
-import {execute} from 'src/frontend/utils/executeUtils';
+import { execute } from 'src/frontend/utils/executeUtils';
 import { RecordDetailsPage } from 'src/frontend/views/RecordPage';
 import appPackage from 'src/package.json';
 import { SqluiCore, SqluiEnums, SqluiFrontend } from 'typings';
-
-
 
 export type Command = {
   event: SqluiEnums.ClientEventKey;
@@ -939,18 +936,18 @@ export default function MissionControl() {
       const storageDir = serverConfigs?.storageDir || '';
       let shouldCopyToClipboard = true;
 
-      if(!storageDir){
+      if (!storageDir) {
         return;
       }
 
       // copy the path to clipboard
       navigator.clipboard.writeText(storageDir);
 
-      if(window.isElectron){
-        if(platform === 'win32'){
-          execute(`explorer.exe "${storageDir}"`)
-        } else if(platform === 'darwin'){
-          execute(`open "${storageDir}"`)
+      if (window.isElectron) {
+        if (platform === 'win32') {
+          execute(`explorer.exe "${storageDir}"`);
+        } else if (platform === 'darwin') {
+          execute(`open "${storageDir}"`);
         } else {
           // anything else
         }

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -42,9 +42,13 @@ import {
   getExportedConnection,
   getExportedQuery,
 } from 'src/frontend/utils/commonUtils';
+
+import {execute} from 'src/frontend/utils/executeUtils';
 import { RecordDetailsPage } from 'src/frontend/views/RecordPage';
 import appPackage from 'src/package.json';
 import { SqluiCore, SqluiEnums, SqluiFrontend } from 'typings';
+
+
 
 export type Command = {
   event: SqluiEnums.ClientEventKey;
@@ -931,8 +935,26 @@ export default function MissionControl() {
     };
 
     const onRevealDataLocation = () => {
+      const platform = window?.process?.platform;
+      const storageDir = serverConfigs?.storageDir || '';
+      let shouldCopyToClipboard = true;
+
+      if(!storageDir){
+        return;
+      }
+
       // copy the path to clipboard
-      navigator.clipboard.writeText(serverConfigs?.storageDir || '');
+      navigator.clipboard.writeText(storageDir);
+
+      if(window.isElectron){
+        if(platform === 'win32'){
+          execute(`explorer.exe "${storageDir}"`)
+        } else if(platform === 'darwin'){
+          execute(`open "${storageDir}"`)
+        } else {
+          // anything else
+        }
+      }
     };
 
     await modal({

--- a/src/frontend/utils/executeUtils.ts
+++ b/src/frontend/utils/executeUtils.ts
@@ -1,0 +1,16 @@
+// @ts-ignore
+const { exec } =  window.requireElectron('child_process');
+
+export function execute(shellToRun: string, delay = 25): Promise<string> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      exec(shellToRun, (error, stdout, stderr) => {
+        if (error) {
+          return reject(stderr);
+        }
+
+        resolve(stdout);
+      });
+    }, delay);
+  });
+}

--- a/src/frontend/utils/executeUtils.ts
+++ b/src/frontend/utils/executeUtils.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-const { exec } =  window.requireElectron('child_process');
+const { exec } = window.requireElectron('child_process');
 
 export function execute(shellToRun: string, delay = 25): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
- Reveal location storage in an explorer when clicking on the link and also copy the path to clipboard.
- Confirmed on windows, needs to be confirmed on mac

### Screenshots
![image](https://user-images.githubusercontent.com/3792401/180660214-b1d5b8c7-46cb-4efb-ae96-aa51baa596f8.png)
![image](https://user-images.githubusercontent.com/3792401/180660229-0bfbb0af-3569-40dc-b984-1a4d732ad62a.png)

