### PR TITLE
Fixed dev mode not running after introducing `exec` method

### DIFF
--- a/src/frontend/utils/executeUtils.ts
+++ b/src/frontend/utils/executeUtils.ts
@@ -1,7 +1,11 @@
-// @ts-ignore
-const { exec } = window.requireElectron('child_process');
-
 export function execute(shellToRun: string, delay = 25): Promise<string> {
+  if(!window.isElectron){
+    return Promise.resolve('');
+  }
+
+  // @ts-ignore
+  const { exec } = window.requireElectron('child_process');
+
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       exec(shellToRun, (error, stdout, stderr) => {

--- a/src/frontend/utils/executeUtils.ts
+++ b/src/frontend/utils/executeUtils.ts
@@ -1,5 +1,5 @@
 export function execute(shellToRun: string, delay = 25): Promise<string> {
-  if(!window.isElectron){
+  if (!window.isElectron) {
     return Promise.resolve('');
   }
 


### PR DESCRIPTION
- Fixed dev mode not running after introducing `exec` method

#### Main error
```
Uncaught TypeError: window.requireElectron is not a function
```