### PR TITLE
Connect via the Cassandra support to Cosmos DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,16 @@ VALUES
 
 Cassandra Keyspaces are mapped to sqlui-native databases. And Cassandra Column Families are mapped to sqlui-native table.
 
-
 #### How to get connection string for CosmosDB with Cassandra API?
+
 - Go to `Connection String` of the Azure CosmosDB Cassandra
 
 ![image](https://user-images.githubusercontent.com/3792401/181765317-6a63b300-ee0e-4041-a49c-e4ec6a698b39.png)
 
 ##### Sample CosmosDB with Cassandra API Connection String
+
 It will look something like this.
+
 ```
 cassandra://USERNAME:PRIMARY PASSWORD@CONTACT POINT:PORT
 ```
@@ -305,6 +307,7 @@ Here's how to set up the connection. Open your resource, and click on `Keys`. Th
 ![image](https://user-images.githubusercontent.com/3792401/168093067-fe0aa98c-297c-4f11-a16e-8c60797de800.png)
 
 ##### Sample CosmosDB with Core SQL API Connection String
+
 It will look something like this.
 
 ```

--- a/README.md
+++ b/README.md
@@ -263,6 +263,18 @@ VALUES
 
 Cassandra Keyspaces are mapped to sqlui-native databases. And Cassandra Column Families are mapped to sqlui-native table.
 
+
+#### How to get connection string for CosmosDB with Cassandra API?
+- Go to `Connection String` of the Azure CosmosDB Cassandra
+
+![image](https://user-images.githubusercontent.com/3792401/181765317-6a63b300-ee0e-4041-a49c-e4ec6a698b39.png)
+
+##### Sample CosmosDB with Cassandra API Connection String
+It will look something like this.
+```
+cassandra://USERNAME:PRIMARY PASSWORD@CONTACT POINT:PORT
+```
+
 ### MongoDB Limitations
 
 MongoDB Collections is mapped to sqlui-native table. We scan the first 5 Documents to come up with the schema for the columns.
@@ -285,14 +297,15 @@ Azure CosmosDB Databases are mapped to sqlui-native Databases. And Azure CosmosD
 
 Tested for Azure CosmosDB (with Core SQL).
 
-#### Setting up connection string
+#### How to get connection string for CosmosDB with Core SQL API?
 
 Here's how to set up the connection. Open your resource, and click on `Keys`. Then copy and use either `PRIMARY CONNECTION STRING` or `SECONDARY CONNECTION STRING`
 
 ![image](https://user-images.githubusercontent.com/3792401/168092880-28d066ad-725f-429a-8ebf-92bb7f4f6d68.png)
 ![image](https://user-images.githubusercontent.com/3792401/168093067-fe0aa98c-297c-4f11-a16e-8c60797de800.png)
 
-Sample connection will look like this
+##### Sample CosmosDB with Core SQL API Connection String
+It will look something like this.
 
 ```
 cosmosdb://<your_primary_connection_string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.55.22",
+  "version": "1.56.0",
   "packageManager": "yarn@1.22.19",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/common/adapters/BaseDataAdapter/index.spec.ts
+++ b/src/common/adapters/BaseDataAdapter/index.spec.ts
@@ -65,13 +65,15 @@ Array [
 ]
 `);
     });
-
-
     test('input that needs to be encoded properly', async () => {
-      const config = BaseDataAdapter.getConnectionParameters('cassandra://sqlui-native-17823707621378612879:some_strong-PasswordMa+9T=]-G?We4Pp$wcUK==@sqlui-native-17823707621378612879.cassandra.cosmos.azure.com:10350');
+      const config = BaseDataAdapter.getConnectionParameters(
+        'cassandra://sqlui-native-17823707621378612879:some_strong-PasswordMa+9T=]-G?We4Pp$wcUK==@sqlui-native-17823707621378612879.cassandra.cosmos.azure.com:10350',
+      );
       expect(config?.scheme).toBe('cassandra');
-      expect(config?.username).toMatchInlineSnapshot(`"sqlui-native-17823707621378612879"`)
-      expect(config?.password).toMatchInlineSnapshot(`"some_strong-PasswordMa+9T=]-G?We4Pp$wcUK=="`)
+      expect(config?.username).toMatchInlineSnapshot(`"sqlui-native-17823707621378612879"`);
+      expect(config?.password).toMatchInlineSnapshot(
+        `"some_strong-PasswordMa+9T=]-G?We4Pp$wcUK=="`,
+      );
       expect(config?.hosts).toMatchInlineSnapshot(`
 Array [
   Object {
@@ -79,8 +81,7 @@ Array [
     "port": 10350,
   },
 ]
-`)
+`);
     });
-
   });
 });

--- a/src/common/adapters/BaseDataAdapter/index.spec.ts
+++ b/src/common/adapters/BaseDataAdapter/index.spec.ts
@@ -2,7 +2,7 @@ import BaseDataAdapter from 'src/common/adapters/BaseDataAdapter/index';
 
 describe('BaseDataAdapter', () => {
   describe('getConnectionParameters', () => {
-    test('basic input should work ', async () => {
+    test('basic input should work', async () => {
       const config = BaseDataAdapter.getConnectionParameters('cassandra://localhost:9042');
       expect(config?.scheme).toBe('cassandra');
       expect(config?.hosts).toMatchInlineSnapshot(`
@@ -65,5 +65,22 @@ Array [
 ]
 `);
     });
+
+
+    test('input that needs to be encoded properly', async () => {
+      const config = BaseDataAdapter.getConnectionParameters('cassandra://sqlui-native-17823707621378612879:some_strong-PasswordMa+9T=]-G?We4Pp$wcUK==@sqlui-native-17823707621378612879.cassandra.cosmos.azure.com:10350');
+      expect(config?.scheme).toBe('cassandra');
+      expect(config?.username).toMatchInlineSnapshot(`"sqlui-native-17823707621378612879"`)
+      expect(config?.password).toMatchInlineSnapshot(`"some_strong-PasswordMa+9T=]-G?We4Pp$wcUK=="`)
+      expect(config?.hosts).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "host": "sqlui-native-17823707621378612879.cassandra.cosmos.azure.com",
+    "port": 10350,
+  },
+]
+`)
+    });
+
   });
 });

--- a/src/common/adapters/BaseDataAdapter/index.ts
+++ b/src/common/adapters/BaseDataAdapter/index.ts
@@ -41,7 +41,23 @@ export default abstract class BaseDataAdapter {
         scheme: dialect,
         hosts: [],
       });
-      return connectionStringParser.parse(connection);
+      let res = connectionStringParser.parse(connection);
+
+      if(!res || Object.keys(res).length === 0){
+        try{
+          // here we attempt to encode and retry parser
+          let connectionParts = connection.replace(`${dialect}://`,'').split(/[:@]/);
+          if(connectionParts.length === 4){
+            // there are 4 parts: username, password, host, port
+            const [username, password, host, port] = connectionParts.map(encodeURIComponent);
+            res = connectionStringParser.parse(`${dialect}://${username}:${password}@${host}:${port}`);
+          }
+        } catch(err){}
+      }
+
+      if(Object.keys(res).length > 0){
+        return res;
+      }
     }
 
     // not supported

--- a/src/common/adapters/BaseDataAdapter/index.ts
+++ b/src/common/adapters/BaseDataAdapter/index.ts
@@ -43,19 +43,21 @@ export default abstract class BaseDataAdapter {
       });
       let res = connectionStringParser.parse(connection);
 
-      if(!res || Object.keys(res).length === 0){
-        try{
+      if (!res || Object.keys(res).length === 0) {
+        try {
           // here we attempt to encode and retry parser
-          let connectionParts = connection.replace(`${dialect}://`,'').split(/[:@]/);
-          if(connectionParts.length === 4){
+          let connectionParts = connection.replace(`${dialect}://`, '').split(/[:@]/);
+          if (connectionParts.length === 4) {
             // there are 4 parts: username, password, host, port
             const [username, password, host, port] = connectionParts.map(encodeURIComponent);
-            res = connectionStringParser.parse(`${dialect}://${username}:${password}@${host}:${port}`);
+            res = connectionStringParser.parse(
+              `${dialect}://${username}:${password}@${host}:${port}`,
+            );
           }
-        } catch(err){}
+        } catch (err) {}
       }
 
-      if(Object.keys(res).length > 0){
+      if (Object.keys(res).length > 0) {
         return res;
       }
     }

--- a/src/common/adapters/CassandraDataAdapter/index.ts
+++ b/src/common/adapters/CassandraDataAdapter/index.ts
@@ -29,7 +29,7 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
         }
 
         const clientOptions: cassandra.ClientOptions = {
-          contactPoints: [`${connectionHosts[0].host}:${connectionHosts[0].port}`],
+          contactPoints: [`${connectionHosts[0].host}:${connectionHosts[0].port || 9042}`],
         };
 
         if (database) {

--- a/src/common/adapters/CassandraDataAdapter/index.ts
+++ b/src/common/adapters/CassandraDataAdapter/index.ts
@@ -29,12 +29,12 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
         }
 
         const clientOptions: cassandra.ClientOptions = {
-          contactPoints: [connectionHosts[0].host],
-          protocolOptions: {
-            port: connectionHosts[0].port,
-          },
-          keyspace: database,
+          contactPoints: [`${connectionHosts[0].host}:${connectionHosts[0].port}`],
         };
+
+        if(database){
+          clientOptions.keyspace = database;
+        }
 
         // client authentication
         let authProvider: cassandra.auth.PlainTextAuthProvider | undefined;
@@ -45,11 +45,29 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
           );
         }
 
-        const client = new cassandra.Client(clientOptions);
-        await this.authenticateClient(client);
-
-        resolve(client);
+        try{
+          // attempt #1: connect with SSL
+          const client = new cassandra.Client({
+            ...clientOptions,
+            ...{
+              sslOptions: {
+                // for Cosmosdb (Cassandra API)
+                // refer to this
+                // https://docs.microsoft.com/en-us/azure/developer/javascript/how-to/with-database/use-cassandra-as-cosmos-db#use-native-sdk-packages-to-connect-to-cassandra-db-on-azure
+                rejectUnauthorized: false,
+              }
+            }
+          });
+          await this.authenticateClient(client);
+          resolve(client);
+        } catch(err1){
+          // attempt #2: connect without SSL
+          const client = new cassandra.Client(clientOptions);
+          await this.authenticateClient(client);
+          resolve(client);
+        }
       } catch (err) {
+        console.log('Failed to getConnection', this.dialect, err)
         reject(err);
       }
     });

--- a/src/common/adapters/CassandraDataAdapter/index.ts
+++ b/src/common/adapters/CassandraDataAdapter/index.ts
@@ -32,7 +32,7 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
           contactPoints: [`${connectionHosts[0].host}:${connectionHosts[0].port}`],
         };
 
-        if(database){
+        if (database) {
           clientOptions.keyspace = database;
         }
 
@@ -45,7 +45,7 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
           );
         }
 
-        try{
+        try {
           // attempt #1: connect with SSL
           const client = new cassandra.Client({
             ...clientOptions,
@@ -55,19 +55,19 @@ export default class CassandraDataAdapter extends BaseDataAdapter implements IDa
                 // refer to this
                 // https://docs.microsoft.com/en-us/azure/developer/javascript/how-to/with-database/use-cassandra-as-cosmos-db#use-native-sdk-packages-to-connect-to-cassandra-db-on-azure
                 rejectUnauthorized: false,
-              }
-            }
+              },
+            },
           });
           await this.authenticateClient(client);
           resolve(client);
-        } catch(err1){
+        } catch (err1) {
           // attempt #2: connect without SSL
           const client = new cassandra.Client(clientOptions);
           await this.authenticateClient(client);
           resolve(client);
         }
       } catch (err) {
-        console.log('Failed to getConnection', this.dialect, err)
+        console.log('Failed to getConnection', this.dialect, err);
         reject(err);
       }
     });


### PR DESCRIPTION
Fixes #537
- Fixes the connectionParser to properly encode the connection metadata using `encodeURIComponent`.
- Connect via the Cassandra support to Cosmos DB. First will attempt to connect with SSL check, if failed then fallback to connect without SSL.

#### How to get connection string for CosmosDB with Cassandra API?
Go to `Connection String` of the Azure CosmosDB Cassandra
![image](https://user-images.githubusercontent.com/3792401/181765317-6a63b300-ee0e-4041-a49c-e4ec6a698b39.png)


#### Sample connection string
The connection string for sqluinative will be something like this.
```
cassandra://USERNAME:PRIMARY PASSWORD@CONTACT POINT:PORT
```