### PR TITLE
Now use `virtualize` to render large data lists faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@mui/icons-material": "^5.8.2",
     "@mui/lab": "^5.0.0-alpha.89",
     "@mui/material": "^5.8.2",
+    "@tanstack/react-virtual": "^3.0.0-beta.14",
     "cassandra-driver": "^3.6.0",
     "connection-string-parser": "^1.0.4",
     "fuzzysort": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.56.2",
+  "version": "1.57.0",
   "packageManager": "yarn@1.22.19",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -35,35 +35,6 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
-function TableContainerWrapper(props: any): JSX.Element | null {
-  return (
-    <Paper square={true} variant='outlined' sx={{ overflow: 'auto' }}>
-      {props.children}
-    </Paper>
-  );
-}
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
-  [`&.${tableCellClasses.head}`]: {
-    backgroundColor: theme.palette.common.black,
-    color: theme.palette.common.white,
-  },
-  [`&.${tableCellClasses.body}`]: {
-    fontSize: '1rem',
-  },
-}));
-
-const StyledTableRow = styled(TableRow)(({ theme }) => ({
-  '&:nth-of-type(odd)': {
-    backgroundColor: theme.palette.action.hover,
-  },
-  '&:last-child td, &:last-child th': {
-    border: 0,
-  },
-  '&:hover': {
-    backgroundColor: theme.palette.action.focus,
-  },
-}));
-
 const StyledDivRow = styled('div')(({ theme }) => ({
   position: 'absolute',
   top: 0,
@@ -71,6 +42,25 @@ const StyledDivRow = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   gap: 2,
+  fontSize: '1rem',
+
+  '&:nth-of-type(odd)': {
+    backgroundColor: theme.palette.action.hover,
+  },
+
+  '&.header': {
+    backgroundColor: theme.palette.common.black,
+    color: theme.palette.common.white,
+    fontWeight: 'bold',
+  },
+
+  '&:hover': {
+    backgroundColor: theme.palette.action.focus,
+  },
+}));
+
+const StyledDivContainer = styled('div')(({ theme }) => ({
+
 }));
 
 export default function DataTable(props: DataTableProps): JSX.Element | null {
@@ -159,7 +149,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
         }}
       >
       {/* The large inner element to hold all of the items */}
-        <Box
+        <StyledDivContainer
           sx={{
             height: `${rowVirtualizer.getTotalSize()}px`,
             width: '100%',
@@ -174,6 +164,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
               return <>
                {headerGroups.map((headerGroup, headerGroupIdx) => (
                 <StyledDivRow
+                className='header'
                 sx={{
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
@@ -231,7 +222,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                   })}
               </StyledDivRow>
             )})}
-        </Box>
+        </StyledDivContainer>
 
       </Box>
       <TablePagination

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -29,8 +29,9 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
 const tableCellHeight = 30;
+const tableCellWidth = 125;
 
-const tableCellWidth = 100;
+const StyledDivContainer = styled('div')(({ theme }) => ({}));
 
 const StyledDivHeaderRow = styled('div')(({ theme }) => ({
   fontWeight: 'bold',
@@ -41,21 +42,17 @@ const StyledDivHeaderRow = styled('div')(({ theme }) => ({
   position: 'sticky',
   top: 0,
   left: 0,
-  right: 0,
   zIndex: theme.zIndex.drawer + 1,
   backgroundColor: theme.palette.common.black,
+  color: theme.palette.common.white,
+  borderBottom: `1px solid ${theme.palette.divider}`,
 
   '> div': {
-    flexShrink: 0,
-    width: `${tableCellWidth}px`,
     height: `${tableCellHeight}px`,
     backgroundColor: theme.palette.common.black,
     color: theme.palette.common.white,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingTop: '5px',
     boxSizing: 'border-box',
-    paddingInline: '0.5rem',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     wordBreak: 'break-all',
@@ -67,33 +64,26 @@ const StyledDivContentRow = styled('div')(({ theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
-  right: 0,
   display: 'flex',
   alignItems: 'center',
   fontSize: '1rem',
   userSelect: 'none',
+  backgroundColor: theme.palette.action.selected,
 
   '&:nth-of-type(odd)': {
     backgroundColor: theme.palette.action.hover,
   },
 
-  '&.header': {
-    backgroundColor: theme.palette.common.black,
-    color: theme.palette.common.white,
-    fontWeight: 'bold',
-  },
-
   '&:hover': {
     backgroundColor: theme.palette.action.focus,
   },
-
-  '> div': {
-    flexShrink: 0,
-    width: `${tableCellWidth}px`,
-  },
 }));
 
-const StyledDivContainer = styled('div')(({ theme }) => ({}));
+const StyledDivContentCell = styled('div')(({ theme }) => ({
+  flexShrink: 0,
+  width: `${tableCellWidth}px`,
+  paddingInline: '0.5rem',
+}));
 
 export default function DataTable(props: DataTableProps): JSX.Element | null {
   const { columns, data } = props;
@@ -182,7 +172,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
           {headerGroups.map((headerGroup, headerGroupIdx) => (
             <StyledDivHeaderRow {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column, colIdx) => (
-                <Box {...column.getHeaderProps()}>{column.render('Header')}</Box>
+                <StyledDivContentCell {...column.getHeaderProps()}>{column.render('Header')}</StyledDivContentCell>
               ))}
             </StyledDivHeaderRow>
           ))}
@@ -223,10 +213,10 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                     );
                   }
                   return (
-                    <Box {...cell.getCellProps()}>
+                    <StyledDivContentCell {...cell.getCellProps()}>
                       {dropdownContent}
                       {cell.render('Cell')}
-                    </Box>
+                    </StyledDivContentCell>
                   );
                 })}
               </StyledDivContentRow>

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -67,6 +67,7 @@ const StyledDivContentRow = styled('div')(({ theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
+  right: 0,
   display: 'flex',
   alignItems: 'center',
   fontSize: '1rem',

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -157,17 +157,10 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
   // The virtualizer
   const rowVirtualizer = useVirtualizer({
     count: page.length,
+    paddingStart: tableCellHeight,
     getScrollElement: () => parentRef.current,
     estimateSize: () => tableCellHeight,
   });
-
-  const columnVirtualizer = useVirtualizer({
-    horizontal: true,
-    count: columns.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: (i) => tableCellWidth,
-    overscan: 5,
-  })
 
   return (
     <>
@@ -202,25 +195,22 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
               ))}
             </StyledDivHeaderRow>
           ))}
-          {rowVirtualizer.getVirtualItems().map((rowVirtualItem) => {
-            const rowIdx = rowVirtualItem.index;
+          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+            let rowIdx = virtualItem.index;
             const row = page[rowIdx];
             prepareRow(row);
 
             return (
               <StyledDivContentRow
-                key={rowVirtualItem.key}
+                key={virtualItem.key}
                 onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
                 onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
                 style={{
                   cursor: props.onRowClick ? 'pointer' : '',
-                  height: `${rowVirtualItem.size}px`,
-                  transform: `translateY(${rowVirtualItem.start + tableCellHeight}px)`,
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
                 }}>
-                {columnVirtualizer.getVirtualItems().map((cellVirtualItem) => {
-                  const colIdx = rowVirtualItem.index;
-                  const cell = row.cells[colIdx];
-
+                {row.cells.map((cell, colIdx) => {
                   let dropdownContent: any;
                   if (colIdx === 0 && targetRowContextOptions.length > 0) {
                     dropdownContent = (

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -135,19 +135,12 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
     setPageSize(e.target.value);
   }, []);
 
-  const onRowContextMenuClick = (e: React.SyntheticEvent) => {
-    const target = e.target as HTMLElement;
-    const tr = target.closest('tr');
-    const siblings = target.closest('tbody')?.children;
-    if (siblings) {
-      for (let rowIdx = 0; rowIdx < siblings.length; rowIdx++) {
-        if (siblings[rowIdx] === tr) {
-          e.preventDefault();
-          setOpenContextMenuRowIdx(rowIdx);
-          anchorEl.current = target;
-          break;
-        }
-      }
+  const onRowContextMenuClick = (e: React.SyntheticEvent, rowIdx: number) => {
+    if(rowIdx >= 0){
+      e.preventDefault();
+      const target = e.target as HTMLElement;
+      setOpenContextMenuRowIdx(rowIdx);
+      anchorEl.current = target;
     }
   };
 
@@ -202,6 +195,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
               <StyledDivContentRow
                 key={virtualItem.key}
                 onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
+                onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
                 style={{
                   cursor:props.onRowClick? 'pointer': '',
                   height: `${virtualItem.size}px`,

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -64,6 +64,15 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
   },
 }));
 
+const StyledDivRow = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+}));
+
 export default function DataTable(props: DataTableProps): JSX.Element | null {
   const { columns, data } = props;
   const [openContextMenuRowIdx, setOpenContextMenuRowIdx] = useState(-1);
@@ -164,16 +173,10 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
             if(rowIdx < 0){
               return <>
                {headerGroups.map((headerGroup, headerGroupIdx) => (
-                <Box
+                <StyledDivRow
                 sx={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
                 }}
                {...headerGroup.getHeaderGroupProps()}>
                   {headerGroup.headers.map((column, colIdx) => (
@@ -183,7 +186,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                       {column.render('Header')}
                     </Box>
                   ))}
-                </Box>
+                </StyledDivRow>
               ))}
               </>
             }
@@ -192,17 +195,11 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
             prepareRow(row);
 
             return (
-              <Box
+              <StyledDivRow
                 key={virtualItem.key}
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
+                style={{
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
                 }}
               >
                 {row.cells.map((cell, colIdx) => {
@@ -232,7 +229,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                       </Box>
                     );
                   })}
-              </Box>
+              </StyledDivRow>
             )})}
         </Box>
 

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -99,8 +99,6 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
     pageSizeToUse = allRecordSize;
   }
 
-  const pageSizeOptions = ALL_PAGE_SIZE_OPTIONS.map((option) => ({ ...option }));
-  pageSizeOptions[pageSizeOptions.length - 1].value = allRecordSize;
 
   const {
     getTableBodyProps,

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -132,40 +132,26 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
 
   // The virtualizer
   const rowVirtualizer = useVirtualizer({
-    count: page.length,
+    count: page.length + 1,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 55,
+    estimateSize: () => 30,
   })
 
   const tableHeight = '500px';
 
   return (
     <>
-      <Box>
-       {headerGroups.map((headerGroup) => (
-        <Box {...headerGroup.getHeaderGroupProps()}>
-          {headerGroup.headers.map((column, colIdx) => (
-            <Box
-              {...column.getHeaderProps()}
-              sx={{ width: columns[colIdx].width }}>
-              {column.render('Header')}
-            </Box>
-          ))}
-        </Box>
-      ))}
-      </Box>
-
        {/* The scrollable element for your list */}
       <Box
         ref={parentRef}
-        style={{
+        sx={{
           height: `400px`,
           overflow: 'auto', // Make it scroll!
         }}
       >
       {/* The large inner element to hold all of the items */}
         <Box
-          style={{
+          sx={{
             height: `${rowVirtualizer.getTotalSize()}px`,
             width: '100%',
             position: 'relative',
@@ -173,22 +159,40 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
         >
           {/* Only the visible items in the virtualizer, manually positioned to be in view */}
           {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-            const rowIdx = virtualItem.index;
+            let rowIdx = virtualItem.index - 1;
+
+            if(rowIdx < 0){
+              return <Box>
+               {headerGroups.map((headerGroup) => (
+                <Box {...headerGroup.getHeaderGroupProps()}
+                 sx={{display: 'flex', gap: 2, }}>
+                  {headerGroup.headers.map((column, colIdx) => (
+                    <Box
+                      {...column.getHeaderProps()}
+                      sx={{ width: columns[colIdx].width }}>
+                      {column.render('Header')}
+                    </Box>
+                  ))}
+                </Box>
+              ))}
+              </Box>
+            }
+
             const row = page[rowIdx];
             prepareRow(row);
 
             return (
               <Box
                 key={virtualItem.key}
-                style={{
+                sx={{
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  width: '100%',
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
                   display: 'flex',
-                  gap: '2rem',
+                  alignItems: 'center',
+                  gap: 2,
                 }}
               >
                 {row.cells.map((cell, colIdx) => {
@@ -212,7 +216,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                       );
                     }
                     return (
-                      <Box {...cell.getCellProps()}>
+                      <Box {...cell.getCellProps()} sx={{width: columns[colIdx].width}}>
                         {dropdownContent}
                         {cell.render('Cell')}
                       </Box>

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,4 +1,5 @@
 import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -140,46 +141,57 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
 
   return (
     <>
-      <TableContainer component={TableContainerWrapper}>
-        <Table sx={{ minWidth: 650, height: tableHeight, overflow: 'auto' }} size='small' ref={parentRef}>
-          <TableHead>
-            {headerGroups.map((headerGroup) => (
-              <TableRow {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column, colIdx) => (
-                  <StyledTableCell
-                    {...column.getHeaderProps()}
-                    sx={{ width: columns[colIdx].width }}>
-                    {column.render('Header')}
-                  </StyledTableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableHead>
-          <TableBody {...getTableBodyProps()} onContextMenu={(e) => onRowContextMenuClick(e)}
-           sx={{
+      <Box>
+       {headerGroups.map((headerGroup) => (
+        <Box {...headerGroup.getHeaderGroupProps()}>
+          {headerGroup.headers.map((column, colIdx) => (
+            <Box
+              {...column.getHeaderProps()}
+              sx={{ width: columns[colIdx].width }}>
+              {column.render('Header')}
+            </Box>
+          ))}
+        </Box>
+      ))}
+      </Box>
+
+       {/* The scrollable element for your list */}
+      <Box
+        ref={parentRef}
+        style={{
+          height: `400px`,
+          overflow: 'auto', // Make it scroll!
+        }}
+      >
+      {/* The large inner element to hold all of the items */}
+        <Box
+          style={{
             height: `${rowVirtualizer.getTotalSize()}px`,
             width: '100%',
             position: 'relative',
           }}
-          >
-            {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-              const rowIdx = virtualItem.index;
-              const row = page[rowIdx];
-              prepareRow(row);
-              return (
-                <StyledTableRow
-                  {...row.getRowProps()}
-                  onClick={() => props.onRowClick && props.onRowClick(row.original)}
-                  style={{
-                    cursor: props.onRowClick ? 'pointer' : '',
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}>
-                  {row.cells.map((cell, colIdx) => {
+        >
+          {/* Only the visible items in the virtualizer, manually positioned to be in view */}
+          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+            const rowIdx = virtualItem.index;
+            const row = page[rowIdx];
+            prepareRow(row);
+
+            return (
+              <Box
+                key={virtualItem.key}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
+                  display: 'flex',
+                  gap: '2rem',
+                }}
+              >
+                {row.cells.map((cell, colIdx) => {
                     let dropdownContent: any;
                     if (colIdx === 0 && targetRowContextOptions.length > 0) {
                       dropdownContent = (
@@ -200,18 +212,17 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                       );
                     }
                     return (
-                      <StyledTableCell {...cell.getCellProps()}>
+                      <Box {...cell.getCellProps()}>
                         {dropdownContent}
                         {cell.render('Cell')}
-                      </StyledTableCell>
+                      </Box>
                     );
                   })}
-                </StyledTableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+              </Box>
+            )})}
+        </Box>
+
+      </Box>
       <TablePagination
         component='div'
         count={data.length}

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,7 +1,6 @@
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
-import TablePagination from '@mui/material/TablePagination';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -30,7 +29,8 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
 const tableCellHeight = 30;
-const tableCellWidth = 100
+
+const tableCellWidth = 100;
 
 const StyledDivHeaderRow = styled('div')(({ theme }) => ({
   fontWeight: 'bold',
@@ -137,7 +137,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
   }, []);
 
   const onRowContextMenuClick = (e: React.SyntheticEvent, rowIdx: number) => {
-    if(rowIdx >= 0){
+    if (rowIdx >= 0) {
       e.preventDefault();
       const target = e.target as HTMLElement;
       setOpenContextMenuRowIdx(rowIdx);
@@ -198,7 +198,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                 onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
                 onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
                 style={{
-                  cursor:props.onRowClick? 'pointer': '',
+                  cursor: props.onRowClick ? 'pointer' : '',
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start + tableCellHeight}px)`,
                 }}>

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -162,20 +162,30 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
             let rowIdx = virtualItem.index - 1;
 
             if(rowIdx < 0){
-              return <Box>
-               {headerGroups.map((headerGroup) => (
-                <Box {...headerGroup.getHeaderGroupProps()}
-                 sx={{display: 'flex', gap: 2, }}>
+              return <>
+               {headerGroups.map((headerGroup, headerGroupIdx) => (
+                <Box
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                }}
+               {...headerGroup.getHeaderGroupProps()}>
                   {headerGroup.headers.map((column, colIdx) => (
                     <Box
                       {...column.getHeaderProps()}
-                      sx={{ width: columns[colIdx].width }}>
+                      sx={{ width: '100px' }}>
                       {column.render('Header')}
                     </Box>
                   ))}
                 </Box>
               ))}
-              </Box>
+              </>
             }
 
             const row = page[rowIdx];
@@ -216,7 +226,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                       );
                     }
                     return (
-                      <Box {...cell.getCellProps()} sx={{width: columns[colIdx].width}}>
+                      <Box {...cell.getCellProps()} sx={{width: '100px'}}>
                         {dropdownContent}
                         {cell.render('Cell')}
                       </Box>

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -250,6 +250,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
     return sortColumnNamesForUnknownData([...newColumnNames]).map((columnName) => {
       return {
         Header: columnName,
+        accessor: (data: any) => data[columnName],
         Cell: (data: any) => {
           const columnValue = data.row.original[columnName];
           if (columnValue === null) {

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -15,6 +15,7 @@ type DataTableProps = {
   data: any[];
   onRowClick?: (rowData: any) => void;
   rowContextOptions?: DropdownButtonOption[];
+  searchInputId?: string;
 };
 
 export const ALL_PAGE_SIZE_OPTIONS: any[] = [
@@ -164,14 +165,16 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
 
   return (
     <>
-      <TextField
-        label="Search Table"
-        size='small'
-        fullWidth
-        onChange={e => setGlobalFilter(e.target.value)}
-        sx={{mb: 2}}
-        variant="standard"
-      />
+      {
+        props.searchInputId && <TextField
+          id={props.searchInputId}
+              label="Search Table"
+              size='small'
+              fullWidth
+              onChange={e => setGlobalFilter(e.target.value)}
+              sx={{mb: 2}}
+              variant="standard"
+            />}
       {
         !page || page.length === 0 ? <Box>There is no data.</Box>
         : <Box

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,3 +1,4 @@
+import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
@@ -28,6 +29,7 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
+const tableHeight = '500px';
 const tableCellHeight = 30;
 const tableCellWidth = 125;
 
@@ -99,7 +101,16 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
   const pageSizeOptions = ALL_PAGE_SIZE_OPTIONS.map((option) => ({ ...option }));
   pageSizeOptions[pageSizeOptions.length - 1].value = allRecordSize;
 
-  const { getTableBodyProps, gotoPage, headerGroups, page, prepareRow, setPageSize, state } =
+  const {
+    getTableBodyProps,
+    gotoPage,
+    headerGroups,
+    page,
+    prepareRow,
+    setGlobalFilter,
+    setPageSize,
+    state,
+   } =
     useTable(
       {
         initialState: {
@@ -151,18 +162,22 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
     estimateSize: () => tableCellHeight,
   });
 
-  const tableHeight = '500px';
-
   return (
     <>
-      {/* The scrollable element for your list */}
+      <TextField
+        label="Search Table"
+        size='small'
+        fullWidth
+        onChange={e => setGlobalFilter(e.target.value)}
+        sx={{mb: 2}}
+        variant="standard"
+      />
       <Box
         ref={parentRef}
         sx={{
-          height: tableHeight,
+          maxHeight: tableHeight,
           overflow: 'auto', // Make it scroll!
         }}>
-        {/* The large inner element to hold all of the items */}
         <StyledDivContainer
           sx={{
             height: `${rowVirtualizer.getTotalSize()}px`,
@@ -176,7 +191,6 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
               ))}
             </StyledDivHeaderRow>
           ))}
-          {/* Only the visible items in the virtualizer, manually positioned to be in view */}
           {rowVirtualizer.getVirtualItems().map((virtualItem) => {
             let rowIdx = virtualItem.index;
             const row = page[rowIdx];

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,7 +1,7 @@
-import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
+import TextField from '@mui/material/TextField';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -31,6 +31,7 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
 const tableHeight = '500px';
+
 const tableCellHeight = 30;
 const tableCellWidth = 125;
 
@@ -98,8 +99,6 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
   if (pageSizeToUse === -1) {
     pageSizeToUse = allRecordSize;
   }
-
-
   const {
     getTableBodyProps,
     gotoPage,
@@ -109,20 +108,19 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
     setGlobalFilter,
     setPageSize,
     state,
-   } =
-    useTable(
-      {
-        initialState: {
-          pageSize: pageSizeToUse,
-        },
-        columns,
-        data,
+  } = useTable(
+    {
+      initialState: {
+        pageSize: pageSizeToUse,
       },
-      useFilters,
-      useGlobalFilter,
-      useSortBy,
-      usePagination,
-    );
+      columns,
+      data,
+    },
+    useFilters,
+    useGlobalFilter,
+    useSortBy,
+    usePagination,
+  );
   const { pageIndex, pageSize } = state;
 
   const onPageChange = useCallback(
@@ -164,85 +162,89 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
 
   return (
     <>
-      {
-        props.searchInputId && <TextField
+      {props.searchInputId && (
+        <TextField
           id={props.searchInputId}
-              label="Search Table"
-              size='small'
-              fullWidth
-              onChange={e => setGlobalFilter(e.target.value)}
-              sx={{mb: 2}}
-              variant="standard"
-            />}
-      {
-        !page || page.length === 0 ? <Box>There is no data.</Box>
-        : <Box
-        ref={parentRef}
-        sx={{
-          maxHeight: tableHeight,
-          overflow: 'auto', // Make it scroll!
-        }}>
-        <StyledDivContainer
+          label='Search Table'
+          size='small'
+          fullWidth
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          sx={{ mb: 2 }}
+          variant='standard'
+        />
+      )}
+      {!page || page.length === 0 ? (
+        <Box>There is no data.</Box>
+      ) : (
+        <Box
+          ref={parentRef}
           sx={{
-            height: `${rowVirtualizer.getTotalSize()}px`,
-            width: '100%',
-            position: 'relative',
+            maxHeight: tableHeight,
+            overflow: 'auto', // Make it scroll!
           }}>
-          {headerGroups.map((headerGroup, headerGroupIdx) => (
-            <StyledDivHeaderRow {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column, colIdx) => (
-                <StyledDivContentCell {...column.getHeaderProps()}>{column.render('Header')}</StyledDivContentCell>
-              ))}
-            </StyledDivHeaderRow>
-          ))}
-          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-            let rowIdx = virtualItem.index;
-            const row = page[rowIdx];
-            prepareRow(row);
+          <StyledDivContainer
+            sx={{
+              height: `${rowVirtualizer.getTotalSize()}px`,
+              width: '100%',
+              position: 'relative',
+            }}>
+            {headerGroups.map((headerGroup, headerGroupIdx) => (
+              <StyledDivHeaderRow {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column, colIdx) => (
+                  <StyledDivContentCell {...column.getHeaderProps()}>
+                    {column.render('Header')}
+                  </StyledDivContentCell>
+                ))}
+              </StyledDivHeaderRow>
+            ))}
+            {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+              let rowIdx = virtualItem.index;
+              const row = page[rowIdx];
+              prepareRow(row);
 
-            return (
-              <StyledDivContentRow
-                key={virtualItem.key}
-                onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
-                onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
-                style={{
-                  cursor: props.onRowClick ? 'pointer' : '',
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}>
-                {row.cells.map((cell, colIdx) => {
-                  let dropdownContent: any;
-                  if (colIdx === 0 && targetRowContextOptions.length > 0) {
-                    dropdownContent = (
-                      <DropdownMenu
-                        id={`data-table-row-dropdown-${rowIdx}`}
-                        options={targetRowContextOptions}
-                        onToggle={(newOpen) => {
-                          if (newOpen) {
-                            setOpenContextMenuRowIdx(rowIdx);
-                          } else {
-                            setOpenContextMenuRowIdx(-1);
-                          }
-                        }}
-                        maxHeight='400px'
-                        anchorEl={anchorEl}
-                        open={openContextMenuRowIdx === rowIdx}
-                      />
+              return (
+                <StyledDivContentRow
+                  key={virtualItem.key}
+                  onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
+                  onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
+                  style={{
+                    cursor: props.onRowClick ? 'pointer' : '',
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}>
+                  {row.cells.map((cell, colIdx) => {
+                    let dropdownContent: any;
+                    if (colIdx === 0 && targetRowContextOptions.length > 0) {
+                      dropdownContent = (
+                        <DropdownMenu
+                          id={`data-table-row-dropdown-${rowIdx}`}
+                          options={targetRowContextOptions}
+                          onToggle={(newOpen) => {
+                            if (newOpen) {
+                              setOpenContextMenuRowIdx(rowIdx);
+                            } else {
+                              setOpenContextMenuRowIdx(-1);
+                            }
+                          }}
+                          maxHeight='400px'
+                          anchorEl={anchorEl}
+                          open={openContextMenuRowIdx === rowIdx}
+                        />
+                      );
+                    }
+                    return (
+                      <StyledDivContentCell {...cell.getCellProps()}>
+                        {dropdownContent}
+                        {cell.render('Cell')}
+                      </StyledDivContentCell>
                     );
-                  }
-                  return (
-                    <StyledDivContentCell {...cell.getCellProps()}>
-                      {dropdownContent}
-                      {cell.render('Cell')}
-                    </StyledDivContentCell>
-                  );
-                })}
-              </StyledDivContentRow>
-            );
-          })}
-        </StyledDivContainer>
-      </Box>
-      }
+                  })}
+                </StyledDivContentRow>
+              );
+            })}
+          </StyledDivContainer>
+        </Box>
+      )}
     </>
   );
 }
@@ -275,7 +277,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
           html.innerHTML = columnValue;
           return html.innerText;
         },
-        Cell: (data: any,a,b,c) => {
+        Cell: (data: any, a, b, c) => {
           const columnValue = data.row.original[columnName];
           if (columnValue === null) {
             return <pre style={{ textTransform: 'uppercase', fontStyle: 'italic' }}>NULL</pre>;

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -170,7 +170,15 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
                 <StyledTableRow
                   {...row.getRowProps()}
                   onClick={() => props.onRowClick && props.onRowClick(row.original)}
-                  style={{ cursor: props.onRowClick ? 'pointer' : '' }}>
+                  style={{
+                    cursor: props.onRowClick ? 'pointer' : '',
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}>
                   {row.cells.map((cell, colIdx) => {
                     let dropdownContent: any;
                     if (colIdx === 0 && targetRowContextOptions.length > 0) {

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -172,7 +172,9 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
         sx={{mb: 2}}
         variant="standard"
       />
-      <Box
+      {
+        !page || page.length === 0 ? <Box>There is no data.</Box>
+        : <Box
         ref={parentRef}
         sx={{
           maxHeight: tableHeight,
@@ -238,6 +240,7 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
           })}
         </StyledDivContainer>
       </Box>
+      }
     </>
   );
 }
@@ -264,8 +267,13 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
     return sortColumnNamesForUnknownData([...newColumnNames]).map((columnName) => {
       return {
         Header: columnName,
-        accessor: (data: any) => data[columnName],
-        Cell: (data: any) => {
+        accessor: (data: any) => {
+          const columnValue = data[columnName];
+          const html = document.createElement('p');
+          html.innerHTML = columnValue;
+          return html.innerText;
+        },
+        Cell: (data: any,a,b,c) => {
           const columnValue = data.row.original[columnName];
           if (columnValue === null) {
             return <pre style={{ textTransform: 'uppercase', fontStyle: 'italic' }}>NULL</pre>;

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -161,6 +161,14 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
     estimateSize: () => tableCellHeight,
   });
 
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: columns.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (i) => tableCellWidth,
+    overscan: 5,
+  })
+
   return (
     <>
       {
@@ -194,22 +202,25 @@ export default function DataTable(props: DataTableProps): JSX.Element | null {
               ))}
             </StyledDivHeaderRow>
           ))}
-          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-            let rowIdx = virtualItem.index;
+          {rowVirtualizer.getVirtualItems().map((rowVirtualItem) => {
+            const rowIdx = rowVirtualItem.index;
             const row = page[rowIdx];
             prepareRow(row);
 
             return (
               <StyledDivContentRow
-                key={virtualItem.key}
+                key={rowVirtualItem.key}
                 onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
                 onContextMenu={(e) => onRowContextMenuClick(e, rowIdx)}
                 style={{
                   cursor: props.onRowClick ? 'pointer' : '',
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start + tableCellHeight}px)`,
+                  height: `${rowVirtualItem.size}px`,
+                  transform: `translateY(${rowVirtualItem.start + tableCellHeight}px)`,
                 }}>
-                {row.cells.map((cell, colIdx) => {
+                {columnVirtualizer.getVirtualItems().map((cellVirtualItem) => {
+                  const colIdx = rowVirtualItem.index;
+                  const cell = row.cells[colIdx];
+
                   let dropdownContent: any;
                   if (colIdx === 0 && targetRowContextOptions.length > 0) {
                     dropdownContent = (

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1350,11 +1350,11 @@ export default function MissionControl() {
             } catch (err) {}
             break;
           case 'f':
-            try{
+            try {
               (document.querySelector('#result-box-search-input') as HTMLInputElement)?.focus();
               e.stopPropagation();
               e.preventDefault();
-            }catch(err){}
+            } catch (err) {}
             break;
         }
       }

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1349,6 +1349,13 @@ export default function MissionControl() {
               e.preventDefault();
             } catch (err) {}
             break;
+          case 'f':
+            try{
+              (document.querySelector('#result-box-search-input') as HTMLInputElement)?.focus();
+              e.stopPropagation();
+              e.preventDefault();
+            }catch(err){}
+            break;
         }
       }
     };

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -137,7 +137,8 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
   return (
     <div className='ResultBox'>
       <Alert severity='info'>
-        Query took <Timer startTime={query?.executionStart} endTime={query?.executionEnd} />. {data?.length > 0 ? `And it returned ${data?.length || 0} records.` : ''}
+        Query took <Timer startTime={query?.executionStart} endTime={query?.executionEnd} />.{' '}
+        {data?.length > 0 ? `And it returned ${data?.length || 0} records.` : ''}
       </Alert>
       <Tabs
         tabIdx={tabIdx}

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -126,6 +126,7 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
         onRowClick={onShowRecordDetails}
         rowContextOptions={rowContextOptions}
         data={data}
+        searchInputId='result-box-search-input'
       />
     </div>,
     <div className='ResultBox__Content' key={`JSON`}>

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -96,7 +96,7 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
 
   const tabHeaders = [
     <>
-      Table{' '}
+      Table
       <Tooltip title='Download Result CSV'>
         <DownloadIcon fontSize='small' onClick={onDownloadCsv} />
       </Tooltip>
@@ -122,6 +122,9 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
 
   const tabContents = [
     <div className='ResultBox__Content' key={`Table`}>
+      <Box sx={{mb: 2}}>
+        Query returned {data?.length || 0} Record(s)
+      </Box>
       <DataTableWithJSONList
         onRowClick={onShowRecordDetails}
         rowContextOptions={rowContextOptions}

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -29,7 +29,7 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
   if (executing) {
     return (
       <Alert severity='info' icon={<CircularProgress size={15} />}>
-        Loading <Timer startTime={query?.executionStart} endTime={query?.executionEnd} />
+        Loading <Timer startTime={query?.executionStart} />
         ...
       </Alert>
     );

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -122,7 +122,6 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
 
   const tabContents = [
     <div className='ResultBox__Content' key={`Table`}>
-      <Box sx={{ mb: 2 }}>Query returned {data?.length || 0} Record(s)</Box>
       <DataTableWithJSONList
         onRowClick={onShowRecordDetails}
         rowContextOptions={rowContextOptions}
@@ -137,7 +136,7 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
   return (
     <div className='ResultBox'>
       <Alert severity='info'>
-        Query took <Timer startTime={query?.executionStart} endTime={query?.executionEnd} />
+        Query took <Timer startTime={query?.executionStart} endTime={query?.executionEnd} />. {data?.length > 0 ? `And it returned ${data?.length || 0} records.` : ''}
       </Alert>
       <Tabs
         tabIdx={tabIdx}

--- a/src/frontend/components/ResultBox/index.tsx
+++ b/src/frontend/components/ResultBox/index.tsx
@@ -122,9 +122,7 @@ export default function ResultBox(props: ResultBoxProps): JSX.Element | null {
 
   const tabContents = [
     <div className='ResultBox__Content' key={`Table`}>
-      <Box sx={{mb: 2}}>
-        Query returned {data?.length || 0} Record(s)
-      </Box>
+      <Box sx={{ mb: 2 }}>Query returned {data?.length || 0} Record(s)</Box>
       <DataTableWithJSONList
         onRowClick={onShowRecordDetails}
         rowContextOptions={rowContextOptions}

--- a/src/frontend/components/Settings/index.tsx
+++ b/src/frontend/components/Settings/index.tsx
@@ -127,24 +127,26 @@ export default function Settings(props: SettingsProps): JSX.Element | null {
             type='number'
           />
         </div>
-        <Typography className='FormInput__Label' variant='subtitle1'>
-          Table Page Size
-          <Tooltip title='The default table page size used for results table. Note this change only apply to future results.'>
-            <HelpIcon fontSize='small' sx={{ ml: 1 }} />
-          </Tooltip>
-        </Typography>
-        <div className='FormInput__Row'>
-          <Select
-            value={settings.tablePageSize || DEFAULT_TABLE_PAGE_SIZE}
-            onChange={(newValue) => onSettingChange('tablePageSize', newValue)}
-            sx={{ width: '100%' }}>
-            {ALL_PAGE_SIZE_OPTIONS.map((pageSize) => (
-              <option value={pageSize.value} key={pageSize.value}>
-                {pageSize.label}
-              </option>
-            ))}
-          </Select>
-        </div>
+        {/*
+          <Typography className='FormInput__Label' variant='subtitle1'>
+            Table Page Size
+            <Tooltip title='The default table page size used for results table. Note this change only apply to future results.'>
+              <HelpIcon fontSize='small' sx={{ ml: 1 }} />
+            </Tooltip>
+          </Typography>
+          <div className='FormInput__Row'>
+            <Select
+              value={settings.tablePageSize || DEFAULT_TABLE_PAGE_SIZE}
+              onChange={(newValue) => onSettingChange('tablePageSize', newValue)}
+              sx={{ width: '100%' }}>
+              {ALL_PAGE_SIZE_OPTIONS.map((pageSize) => (
+                <option value={pageSize.value} key={pageSize.value}>
+                  {pageSize.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+        */}
         <Typography className='FormInput__Label' variant='subtitle1'>
           Delete Mode
           <Tooltip title='Whether or not to do soft delete and put deleted items into the recycle bin or hard delete to delete it permanently.'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
+"@reach/observe-rect@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
+  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
+
 "@redis/bloom@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.0.2.tgz#42b82ec399a92db05e29fffcdfd9235a5fc15cdf"
@@ -2260,6 +2265,21 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@tanstack/react-virtual@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.14.tgz#4765bd72b3b94d098a6edb1a36f51f1819cc6fd9"
+  integrity sha512-khIS0ZjRaAxLjZx2VLTde4P8BuaQ/8dxoGdFk+vFFkZdJyXMRSHXLCp8ZnVshyMT/t6SovN+4BMfNZnV1jb1Yg==
+  dependencies:
+    "@reach/observe-rect" "^1.1.0"
+    "@tanstack/virtual-core" "3.0.0-beta.14"
+
+"@tanstack/virtual-core@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.14.tgz#5be33feab2a369061eef4f8f82467b7c7342564e"
+  integrity sha512-xtt1J6Z1v5BXv2s23DAaVdma6LsJJmuI8bj87xdWkMnKPE/jlW5zGGN/PHuZrCz/v8QPbjbru0oxq/uBTtXSXA==
+  dependencies:
+    "@reach/observe-rect" "^1.1.0"
 
 "@testing-library/dom@^8.0.0":
   version "8.16.0"


### PR DESCRIPTION
- Introduce `@tanstack/react-virtual` to speed up data table row rendering.
- Fixed a minor issue with timer not properly refreshed for query loading.
- Added `accessor` value for the table data.
- Added global search filter.