### PR TITLE
Bring legacy data table to support dynamic values in MongoDB and other schema-less DB Engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "1.57.6",
+  "version": "1.58.0",
   "packageManager": "yarn@1.22.19",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgresSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/frontend/components/DataTable/Filter.tsx
+++ b/src/frontend/components/DataTable/Filter.tsx
@@ -1,0 +1,49 @@
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TextField from '@mui/material/TextField';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import DropdownMenu from 'src/frontend/components/DropdownMenu';
+import { useTablePageSize } from 'src/frontend/hooks/useSetting';
+import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
+import Chip from '@mui/material/Chip';
+
+
+export function GlobalFilter(props: any){
+  return <TextField
+          id={props.id}
+          label='Search Table'
+          size='small'
+          variant='standard'
+          sx={{ mb: 2 }}
+          fullWidth
+          onChange={(e) => props.onChange(e.target.value)}
+        />
+}
+
+
+// default filter (using text)
+type SimpleColumnFilterProps = {
+  column: {
+    filterValue?: string;
+    setFilter: (newFilterValue: string | undefined) => void;
+  };
+};
+
+export function SimpleColumnFilter({
+  column: { filterValue, setFilter },
+}: SimpleColumnFilterProps) {
+  return (
+    <TextField
+      size='small'
+      placeholder='Filter'
+      value={filterValue || ''}
+      onChange={(e) => setFilter(e.target.value || undefined)}
+    />
+  );
+}

--- a/src/frontend/components/DataTable/Filter.tsx
+++ b/src/frontend/components/DataTable/Filter.tsx
@@ -1,32 +1,19 @@
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
-import Box from '@mui/material/Box';
-import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TextField from '@mui/material/TextField';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
-import DropdownMenu from 'src/frontend/components/DropdownMenu';
-import { useTablePageSize } from 'src/frontend/hooks/useSetting';
-import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
-import Chip from '@mui/material/Chip';
 
-
-export function GlobalFilter(props: any){
-  return <TextField
-          id={props.id}
-          label='Search Table'
-          size='small'
-          variant='standard'
-          sx={{ mb: 2 }}
-          fullWidth
-          onChange={(e) => props.onChange(e.target.value)}
-        />
+export function GlobalFilter(props: any) {
+  return (
+    <TextField
+      id={props.id}
+      label='Search Table'
+      size='small'
+      variant='standard'
+      sx={{ mb: 2 }}
+      fullWidth
+      onChange={(e) => props.onChange(e.target.value)}
+    />
+  );
 }
-
-
 // default filter (using text)
 type SimpleColumnFilterProps = {
   column: {

--- a/src/frontend/components/DataTable/LegacyDataTable.tsx
+++ b/src/frontend/components/DataTable/LegacyDataTable.tsx
@@ -1,0 +1,197 @@
+import Paper from '@mui/material/Paper';
+import { styled } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import DropdownMenu from 'src/frontend/components/DropdownMenu';
+import { useTablePageSize } from 'src/frontend/hooks/useSetting';
+import {DataTableProps} from 'src/frontend/components/DataTable';
+import {SimpleColumnFilter, GlobalFilter} from 'src/frontend/components/DataTable/Filter';
+
+export const ALL_PAGE_SIZE_OPTIONS: any[] = [
+  { label: '10', value: 10 },
+  { label: '25', value: 25 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 },
+  { label: 'Show All', value: -1 },
+];
+
+export const DEFAULT_TABLE_PAGE_SIZE = 50;
+
+function TableContainerWrapper(props: any) {
+  return (
+    <Paper square={true} variant='outlined' sx={{ overflow: 'auto' }}>
+      {props.children}
+    </Paper>
+  );
+}
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  [`&.${tableCellClasses.head}`]: {
+    backgroundColor: theme.palette.common.black,
+    color: theme.palette.common.white,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: '1rem',
+  },
+}));
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  '&:nth-of-type(odd)': {
+    backgroundColor: theme.palette.action.hover,
+  },
+  '&:last-child td, &:last-child th': {
+    border: 0,
+  },
+  '&:hover': {
+    backgroundColor: theme.palette.action.focus,
+  },
+}));
+
+export default function LegacyDataTable(props: DataTableProps) {
+  const { columns, data } = props;
+  const [openContextMenuRowIdx, setOpenContextMenuRowIdx] = useState(-1);
+  const anchorEl = useRef<HTMLElement | null>(null);
+
+  const allRecordSize = data.length;
+  let pageSizeToUse = useTablePageSize() || DEFAULT_TABLE_PAGE_SIZE;
+  if (pageSizeToUse === -1) {
+    pageSizeToUse = allRecordSize;
+  }
+
+  const pageSizeOptions = ALL_PAGE_SIZE_OPTIONS.map((option) => ({ ...option }));
+  pageSizeOptions[pageSizeOptions.length - 1].value = allRecordSize;
+
+  const { getTableBodyProps, gotoPage, headerGroups, page, prepareRow, setPageSize, state, setGlobalFilter } =
+    useTable(
+      {
+        initialState: {
+          pageSize: pageSizeToUse,
+        },
+        columns,
+        data,
+      },
+      useFilters,
+      useGlobalFilter,
+      useSortBy,
+      usePagination,
+    );
+  const { pageIndex, pageSize } = state;
+
+  const onPageChange = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement> | null, page: number) => {
+      gotoPage(page);
+    },
+    [],
+  );
+
+  const onRowsPerPageChange = useCallback((e) => {
+    setPageSize(e.target.value);
+  }, []);
+
+  const onRowContextMenuClick = (e: React.SyntheticEvent) => {
+    const target = e.target as HTMLElement;
+    const tr = target.closest('tr');
+    const siblings = target.closest('tbody')?.children;
+    if (siblings) {
+      for (let rowIdx = 0; rowIdx < siblings.length; rowIdx++) {
+        if (siblings[rowIdx] === tr) {
+          e.preventDefault();
+          setOpenContextMenuRowIdx(rowIdx);
+          anchorEl.current = target;
+          break;
+        }
+      }
+    }
+  };
+
+  const targetRowContextOptions = (props.rowContextOptions || []).map((rowContextOption) => ({
+    ...rowContextOption,
+    onClick: () =>
+      rowContextOption.onClick && rowContextOption.onClick(data[openContextMenuRowIdx]),
+  }));
+
+  return (
+    <>
+      {props.searchInputId && (
+        <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />
+      )}
+      <TableContainer component={TableContainerWrapper}>
+        <Table sx={{ minWidth: 650 }} size='small'>
+          <TableHead>
+            {headerGroups.map((headerGroup) => (
+              <TableRow {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column, colIdx) => (
+                  <StyledTableCell
+                    {...column.getHeaderProps()}
+                    sx={{ width: columns[colIdx].width }}>
+                    {column.render('Header')}
+                  </StyledTableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableHead>
+          <TableBody {...getTableBodyProps()} onContextMenu={(e) => onRowContextMenuClick(e)}>
+            {page.map((row, rowIdx) => {
+              prepareRow(row);
+              return (
+                <StyledTableRow
+                  {...row.getRowProps()}
+                  onDoubleClick={(e) => {
+                    e.preventDefault();
+                    props.onRowClick && props.onRowClick(row.original)
+                  }}
+                  style={{ cursor: props.onRowClick ? 'pointer' : '' }}>
+                  {row.cells.map((cell, colIdx) => {
+                    let dropdownContent: any;
+                    if (colIdx === 0 && targetRowContextOptions.length > 0) {
+                      dropdownContent = (
+                        <DropdownMenu
+                          id={`data-table-row-dropdown-${rowIdx}`}
+                          options={targetRowContextOptions}
+                          onToggle={(newOpen) => {
+                            if (newOpen) {
+                              setOpenContextMenuRowIdx(rowIdx);
+                            } else {
+                              setOpenContextMenuRowIdx(-1);
+                            }
+                          }}
+                          maxHeight='400px'
+                          anchorEl={anchorEl}
+                          open={openContextMenuRowIdx === rowIdx}
+                        />
+                      );
+                    }
+                    return (
+                      <StyledTableCell {...cell.getCellProps()}>
+                        {dropdownContent}
+                        {cell.render('Cell')}
+                      </StyledTableCell>
+                    );
+                  })}
+                </StyledTableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        component='div'
+        count={data.length}
+        onPageChange={onPageChange}
+        onRowsPerPageChange={onRowsPerPageChange}
+        page={pageIndex}
+        rowsPerPage={pageSize}
+        rowsPerPageOptions={pageSizeOptions}
+        showFirstButton
+        showLastButton
+      />
+    </>
+  );
+}

--- a/src/frontend/components/DataTable/LegacyDataTable.tsx
+++ b/src/frontend/components/DataTable/LegacyDataTable.tsx
@@ -1,4 +1,5 @@
 import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -14,6 +15,8 @@ import DropdownMenu from 'src/frontend/components/DropdownMenu';
 import { useTablePageSize } from 'src/frontend/hooks/useSetting';
 import {DataTableProps} from 'src/frontend/components/DataTable';
 import {SimpleColumnFilter, GlobalFilter} from 'src/frontend/components/DataTable/Filter';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 
 export const ALL_PAGE_SIZE_OPTIONS: any[] = [
   { label: '10', value: 10 },
@@ -76,6 +79,8 @@ export default function LegacyDataTable(props: DataTableProps) {
         },
         columns,
         data,
+        // @ts-ignore
+      defaultColumn: { Filter: SimpleColumnFilter },
       },
       useFilters,
       useGlobalFilter,
@@ -131,7 +136,16 @@ export default function LegacyDataTable(props: DataTableProps) {
                   <StyledTableCell
                     {...column.getHeaderProps()}
                     sx={{ width: columns[colIdx].width }}>
-                    {column.render('Header')}
+                    <Box {...column.getSortByToggleProps()} sx={{display: 'flex', alignItems:  'center'}}>
+                      <span>{column.render('Header')}</span>
+                      {column.isSorted &&
+                        (column.isSortedDesc ? (
+                          <ArrowDropDownIcon fontSize='small' />
+                        ) : (
+                          <ArrowDropUpIcon fontSize='small' />
+                        ))}
+                    </Box>
+                    {column.canFilter && <Box sx={{ mt: 1 }}>{column.render('Filter')}</Box>}
                   </StyledTableCell>
                 ))}
               </TableRow>

--- a/src/frontend/components/DataTable/LegacyDataTable.tsx
+++ b/src/frontend/components/DataTable/LegacyDataTable.tsx
@@ -1,5 +1,7 @@
-import Paper from '@mui/material/Paper';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -9,14 +11,11 @@ import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import React, { useCallback, useRef, useState } from 'react';
+import { DataTableProps } from 'src/frontend/components/DataTable';
+import { GlobalFilter, SimpleColumnFilter } from 'src/frontend/components/DataTable/Filter';
 import DropdownMenu from 'src/frontend/components/DropdownMenu';
 import { useTablePageSize } from 'src/frontend/hooks/useSetting';
-import {DataTableProps} from 'src/frontend/components/DataTable';
-import {SimpleColumnFilter, GlobalFilter} from 'src/frontend/components/DataTable/Filter';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 
 export const ALL_PAGE_SIZE_OPTIONS: any[] = [
   { label: '10', value: 10 },
@@ -71,22 +70,30 @@ export default function LegacyDataTable(props: DataTableProps) {
   const pageSizeOptions = ALL_PAGE_SIZE_OPTIONS.map((option) => ({ ...option }));
   pageSizeOptions[pageSizeOptions.length - 1].value = allRecordSize;
 
-  const { getTableBodyProps, gotoPage, headerGroups, page, prepareRow, setPageSize, state, setGlobalFilter } =
-    useTable(
-      {
-        initialState: {
-          pageSize: pageSizeToUse,
-        },
-        columns,
-        data,
-        // @ts-ignore
-      defaultColumn: { Filter: SimpleColumnFilter },
+  const {
+    getTableBodyProps,
+    gotoPage,
+    headerGroups,
+    page,
+    prepareRow,
+    setPageSize,
+    state,
+    setGlobalFilter,
+  } = useTable(
+    {
+      initialState: {
+        pageSize: pageSizeToUse,
       },
-      useFilters,
-      useGlobalFilter,
-      useSortBy,
-      usePagination,
-    );
+      columns,
+      data,
+      // @ts-ignore
+      defaultColumn: { Filter: SimpleColumnFilter },
+    },
+    useFilters,
+    useGlobalFilter,
+    useSortBy,
+    usePagination,
+  );
   const { pageIndex, pageSize } = state;
 
   const onPageChange = useCallback(
@@ -124,9 +131,7 @@ export default function LegacyDataTable(props: DataTableProps) {
 
   return (
     <>
-      {props.searchInputId && (
-        <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />
-      )}
+      {props.searchInputId && <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />}
       <TableContainer component={TableContainerWrapper}>
         <Table sx={{ minWidth: 650 }} size='small'>
           <TableHead>
@@ -136,7 +141,9 @@ export default function LegacyDataTable(props: DataTableProps) {
                   <StyledTableCell
                     {...column.getHeaderProps()}
                     sx={{ width: columns[colIdx].width }}>
-                    <Box {...column.getSortByToggleProps()} sx={{display: 'flex', alignItems:  'center'}}>
+                    <Box
+                      {...column.getSortByToggleProps()}
+                      sx={{ display: 'flex', alignItems: 'center' }}>
                       <span>{column.render('Header')}</span>
                       {column.isSorted &&
                         (column.isSortedDesc ? (
@@ -159,7 +166,7 @@ export default function LegacyDataTable(props: DataTableProps) {
                   {...row.getRowProps()}
                   onDoubleClick={(e) => {
                     e.preventDefault();
-                    props.onRowClick && props.onRowClick(row.original)
+                    props.onRowClick && props.onRowClick(row.original);
                   }}
                   style={{ cursor: props.onRowClick ? 'pointer' : '' }}>
                   {row.cells.map((cell, colIdx) => {

--- a/src/frontend/components/DataTable/ModernDataTable.tsx
+++ b/src/frontend/components/DataTable/ModernDataTable.tsx
@@ -1,0 +1,273 @@
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TextField from '@mui/material/TextField';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import DropdownMenu from 'src/frontend/components/DropdownMenu';
+import { useTablePageSize } from 'src/frontend/hooks/useSetting';
+import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
+import Chip from '@mui/material/Chip';
+import {DataTableProps} from 'src/frontend/components/DataTable';
+import {SimpleColumnFilter, GlobalFilter} from 'src/frontend/components/DataTable/Filter';
+
+const tableHeight = '500px';
+
+const tableCellHeaderHeight = 75;
+
+const tableCellHeight = 35;
+
+const tableCellWidth = 200;
+
+const StyledDivContainer = styled('div')(({ theme }) => ({}));
+
+const StyledDivHeaderRow = styled('div')(({ theme }) => ({
+  fontWeight: 'bold',
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '1rem',
+  flexWrap: 'nowrap',
+  minWidth: '100%',
+  position: 'sticky',
+  top: 0,
+  left: 0,
+  zIndex: theme.zIndex.drawer + 1,
+  backgroundColor: theme.palette.common.black,
+  color: theme.palette.common.white,
+  borderBottom: `1px solid ${theme.palette.divider}`,
+
+  '> div': {
+    height: `${tableCellHeaderHeight}px`,
+    backgroundColor: theme.palette.common.black,
+    color: theme.palette.common.white,
+    paddingTop: '5px',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    wordBreak: 'break-all',
+    whiteSpace: 'nowrap',
+  },
+}));
+
+const StyledDivContentRow = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '0.9rem',
+  userSelect: 'none',
+  minWidth: '100%',
+  backgroundColor: theme.palette.action.selected,
+
+  '&:nth-of-type(odd)': {
+    backgroundColor: theme.palette.action.hover,
+  },
+
+  '&:hover': {
+    backgroundColor: theme.palette.action.focus,
+  },
+}));
+
+const StyledDivContentCell = styled('div')(({ theme }) => ({
+  flexShrink: 0,
+  maxWidth: `200px`,
+  paddingInline: '0.5rem',
+}));
+
+const StyledDivContentCellLabel = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  '> span': {
+    flexGrow: 1,
+  },
+}));
+
+export default function ModernDataTable(props: DataTableProps): JSX.Element | null {
+  const { columns, data } = props;
+  const [openContextMenuRowIdx, setOpenContextMenuRowIdx] = useState(-1);
+  const anchorEl = useRef<HTMLElement | null>(null);
+
+  const allRecordSize = data.length;
+  const pageSizeToUse = allRecordSize;
+  const {
+    getTableBodyProps,
+    gotoPage,
+    headerGroups,
+    page,
+    prepareRow,
+    setGlobalFilter,
+    setPageSize,
+    state,
+  } = useTable(
+    {
+      initialState: {
+        pageSize: pageSizeToUse,
+      },
+      columns,
+      data,
+      // @ts-ignore
+      defaultColumn: { Filter: SimpleColumnFilter },
+    },
+    useFilters,
+    useGlobalFilter,
+    useSortBy,
+    usePagination,
+  );
+  const { pageIndex, pageSize } = state;
+
+  const onPageChange = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement> | null, page: number) => {
+      gotoPage(page);
+    },
+    [],
+  );
+
+  const onRowsPerPageChange = useCallback((e) => {
+    setPageSize(e.target.value);
+  }, []);
+
+  const onRowContextMenuClick = (e: React.SyntheticEvent) => {
+    const target = e.target as HTMLElement;
+    const tr = target.closest('[role=row]') as HTMLElement;
+    const rowIdx = parseInt(tr?.dataset?.rowIdx || '');
+
+    if (rowIdx >= 0) {
+      e.preventDefault();
+      const target = e.target as HTMLElement;
+      setOpenContextMenuRowIdx(rowIdx);
+      anchorEl.current = target;
+    }
+  };
+
+  const targetRowContextOptions = (props.rowContextOptions || []).map((rowContextOption) => ({
+    ...rowContextOption,
+    onClick: () =>
+      rowContextOption.onClick && rowContextOption.onClick(data[openContextMenuRowIdx]),
+  }));
+
+  // figure out the width
+  const headers = headerGroups?.[0]?.headers || [];
+  for (let i = 0; i < headers.length; i++) {
+    const header = headers[i];
+    columns[i].width = Math.max(header.width as number, tableCellWidth);
+    columns[i].width = `${columns[i].width}px`;
+  }
+
+  // The scrollable element for your list
+  const parentRef = React.useRef<HTMLTableElement | null>(null);
+
+  // The virtualizer
+  const rowVirtualizer = useVirtualizer({
+    count: page.length,
+    paddingStart: tableCellHeaderHeight,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => tableCellHeight,
+    overscan: 5,
+  });
+
+  return (
+    <>
+      {props.searchInputId && (
+        <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />
+      )}
+      <Box
+        ref={parentRef}
+        sx={{
+          maxHeight: tableHeight,
+          overflow: 'auto', // Make it scroll!
+        }}
+        onContextMenu={(e) => onRowContextMenuClick(e)}>
+        <StyledDivContainer
+          sx={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            position: 'relative',
+          }}>
+          {headerGroups.map((headerGroup, headerGroupIdx) => (
+            <StyledDivHeaderRow {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column, colIdx) => (
+                <StyledDivContentCell
+                  style={{
+                    width: columns[colIdx].width,
+                  }}
+                  {...column.getHeaderProps()}>
+                  <StyledDivContentCellLabel {...column.getSortByToggleProps()}>
+                    <span>{column.render('Header')}</span>
+                    {column.isSorted &&
+                      (column.isSortedDesc ? (
+                        <ArrowDropDownIcon fontSize='small' />
+                      ) : (
+                        <ArrowDropUpIcon fontSize='small' />
+                      ))}
+                  </StyledDivContentCellLabel>
+                  {column.canFilter && <Box sx={{ mt: 1 }}>{column.render('Filter')}</Box>}
+                </StyledDivContentCell>
+              ))}
+            </StyledDivHeaderRow>
+          ))}
+          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+            let rowIdx = virtualItem.index;
+            const row = page[rowIdx];
+            //@ts-ignore
+            const measureRef = virtualItem.measureRef;
+            prepareRow(row);
+
+            return (
+              <StyledDivContentRow
+                ref={measureRef}
+                data-row-idx={rowIdx}
+                style={{
+                  cursor: props.onRowClick ? 'pointer' : '',
+                  transform: `translateY(${virtualItem.start}px)`,
+                }}
+                onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
+                {...row.getRowProps()}>
+                {row.cells.map((cell, colIdx) => {
+                  let dropdownContent: any;
+                  if (colIdx === 0 && targetRowContextOptions.length > 0) {
+                    dropdownContent = (
+                      <DropdownMenu
+                        id={`data-table-row-dropdown-${rowIdx}`}
+                        options={targetRowContextOptions}
+                        onToggle={(newOpen) => {
+                          if (newOpen) {
+                            setOpenContextMenuRowIdx(rowIdx);
+                          } else {
+                            setOpenContextMenuRowIdx(-1);
+                          }
+                        }}
+                        maxHeight='400px'
+                        anchorEl={anchorEl}
+                        open={openContextMenuRowIdx === rowIdx}
+                      />
+                    );
+                  }
+                  return (
+                    <StyledDivContentCell
+                      style={{
+                        width: columns[colIdx].width,
+                      }}
+                      {...cell.getCellProps()}>
+                      {dropdownContent}
+                      {cell.render('Cell')}
+                    </StyledDivContentCell>
+                  );
+                })}
+              </StyledDivContentRow>
+            );
+          })}
+        </StyledDivContainer>
+        {!page ||
+          (page.length === 0 && (
+            <Box sx={{ paddingInline: 2, paddingBlock: 2 }}>
+              There is no data in the query with matching filters.
+            </Box>
+          ))}
+      </Box>
+    </>
+  );
+}

--- a/src/frontend/components/DataTable/ModernDataTable.tsx
+++ b/src/frontend/components/DataTable/ModernDataTable.tsx
@@ -3,17 +3,12 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
-import TextField from '@mui/material/TextField';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import React, { useCallback, useRef, useState } from 'react';
+import { DataTableProps } from 'src/frontend/components/DataTable';
+import { GlobalFilter, SimpleColumnFilter } from 'src/frontend/components/DataTable/Filter';
 import DropdownMenu from 'src/frontend/components/DropdownMenu';
-import { useTablePageSize } from 'src/frontend/hooks/useSetting';
-import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
-import Chip from '@mui/material/Chip';
-import {DataTableProps} from 'src/frontend/components/DataTable';
-import {SimpleColumnFilter, GlobalFilter} from 'src/frontend/components/DataTable/Filter';
 
 const tableHeight = '500px';
 
@@ -172,9 +167,7 @@ export default function ModernDataTable(props: DataTableProps): JSX.Element | nu
 
   return (
     <>
-      {props.searchInputId && (
-        <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />
-      )}
+      {props.searchInputId && <GlobalFilter id={props.searchInputId} onChange={setGlobalFilter} />}
       <Box
         ref={parentRef}
         sx={{

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,7 +1,6 @@
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TextField from '@mui/material/TextField';
@@ -12,8 +11,11 @@ import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
 import DropdownMenu from 'src/frontend/components/DropdownMenu';
 import { useTablePageSize } from 'src/frontend/hooks/useSetting';
 import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
+import Chip from '@mui/material/Chip';
+import LegacyDataTable from 'src/frontend/components/DataTable/LegacyDataTable';
+import ModernDataTable from 'src/frontend/components/DataTable/ModernDataTable';
 
-type DataTableProps = {
+export type DataTableProps = {
   columns: any[];
   data: any[];
   onRowClick?: (rowData: any) => void;
@@ -34,294 +36,21 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 
 const UNNAMED_PROPERTY_NAME = '<unnamed_property>';
 
-const tableHeight = '500px';
-
-const tableCellHeaderHeight = 75;
-
-const tableCellHeight = 35;
-
-const tableCellWidth = 200;
-
-const StyledDivContainer = styled('div')(({ theme }) => ({}));
-
-const StyledDivHeaderRow = styled('div')(({ theme }) => ({
-  fontWeight: 'bold',
-  display: 'flex',
-  alignItems: 'center',
-  fontSize: '1rem',
-  flexWrap: 'nowrap',
-  minWidth: '100%',
-  position: 'sticky',
-  top: 0,
-  left: 0,
-  zIndex: theme.zIndex.drawer + 1,
-  backgroundColor: theme.palette.common.black,
-  color: theme.palette.common.white,
-  borderBottom: `1px solid ${theme.palette.divider}`,
-
-  '> div': {
-    height: `${tableCellHeaderHeight}px`,
-    backgroundColor: theme.palette.common.black,
-    color: theme.palette.common.white,
-    paddingTop: '5px',
-    boxSizing: 'border-box',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    wordBreak: 'break-all',
-    whiteSpace: 'nowrap',
-  },
-}));
-
-const StyledDivContentRow = styled('div')(({ theme }) => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  display: 'flex',
-  alignItems: 'center',
-  fontSize: '0.9rem',
-  userSelect: 'none',
-  minWidth: '100%',
-  backgroundColor: theme.palette.action.selected,
-
-  '&:nth-of-type(odd)': {
-    backgroundColor: theme.palette.action.hover,
-  },
-
-  '&:hover': {
-    backgroundColor: theme.palette.action.focus,
-  },
-}));
-
-const StyledDivContentCell = styled('div')(({ theme }) => ({
-  flexShrink: 0,
-  maxWidth: `200px`,
-  paddingInline: '0.5rem',
-}));
-
-const StyledDivContentCellLabel = styled('div')(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  '> span': {
-    flexGrow: 1,
-  },
-}));
-// default filter (using text)
-type SimpleColumnFilterProps = {
-  column: {
-    filterValue?: string;
-    setFilter: (newFilterValue: string | undefined) => void;
-  };
-};
-
-export function SimpleColumnFilter({
-  column: { filterValue, setFilter },
-}: SimpleColumnFilterProps) {
-  return (
-    <TextField
-      size='small'
-      placeholder='Filter'
-      value={filterValue || ''}
-      onChange={(e) => setFilter(e.target.value || undefined)}
-    />
-  );
-}
-
-export default function DataTable(props: DataTableProps): JSX.Element | null {
-  const { columns, data } = props;
-  const [openContextMenuRowIdx, setOpenContextMenuRowIdx] = useState(-1);
-  const anchorEl = useRef<HTMLElement | null>(null);
-
-  const allRecordSize = data.length;
-  let pageSizeToUse = useTablePageSize() || DEFAULT_TABLE_PAGE_SIZE;
-  if (pageSizeToUse === -1) {
-    pageSizeToUse = allRecordSize;
-  }
-  const {
-    getTableBodyProps,
-    gotoPage,
-    headerGroups,
-    page,
-    prepareRow,
-    setGlobalFilter,
-    setPageSize,
-    state,
-  } = useTable(
-    {
-      initialState: {
-        pageSize: pageSizeToUse,
-      },
-      columns,
-      data,
-      // @ts-ignore
-      defaultColumn: { Filter: SimpleColumnFilter },
-    },
-    useFilters,
-    useGlobalFilter,
-    useSortBy,
-    usePagination,
-  );
-  const { pageIndex, pageSize } = state;
-
-  const onPageChange = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement> | null, page: number) => {
-      gotoPage(page);
-    },
-    [],
-  );
-
-  const onRowsPerPageChange = useCallback((e) => {
-    setPageSize(e.target.value);
-  }, []);
-
-  const onRowContextMenuClick = (e: React.SyntheticEvent) => {
-    const target = e.target as HTMLElement;
-    const tr = target.closest('[role=row]') as HTMLElement;
-    const rowIdx = parseInt(tr?.dataset?.rowIdx || '');
-
-    if (rowIdx >= 0) {
-      e.preventDefault();
-      const target = e.target as HTMLElement;
-      setOpenContextMenuRowIdx(rowIdx);
-      anchorEl.current = target;
-    }
-  };
-
-  const targetRowContextOptions = (props.rowContextOptions || []).map((rowContextOption) => ({
-    ...rowContextOption,
-    onClick: () =>
-      rowContextOption.onClick && rowContextOption.onClick(data[openContextMenuRowIdx]),
-  }));
-
-  // figure out the width
-  const headers = headerGroups?.[0]?.headers || [];
-  for (let i = 0; i < headers.length; i++) {
-    const header = headers[i];
-    columns[i].width = Math.max(header.width as number, tableCellWidth);
-    columns[i].width = `${columns[i].width}px`;
-  }
-
-  // The scrollable element for your list
-  const parentRef = React.useRef<HTMLTableElement | null>(null);
-
-  // The virtualizer
-  const rowVirtualizer = useVirtualizer({
-    count: page.length,
-    paddingStart: tableCellHeaderHeight,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => tableCellHeight,
-    overscan: 5,
-  });
-
-  return (
-    <>
-      {props.searchInputId && (
-        <TextField
-          id={props.searchInputId}
-          label='Search Table'
-          size='small'
-          variant='standard'
-          sx={{ mb: 2 }}
-          fullWidth
-          onChange={(e) => setGlobalFilter(e.target.value)}
-        />
-      )}
-      <Box
-        ref={parentRef}
-        sx={{
-          maxHeight: tableHeight,
-          overflow: 'auto', // Make it scroll!
-        }}
-        onContextMenu={(e) => onRowContextMenuClick(e)}>
-        <StyledDivContainer
-          sx={{
-            height: `${rowVirtualizer.getTotalSize()}px`,
-            position: 'relative',
-          }}>
-          {headerGroups.map((headerGroup, headerGroupIdx) => (
-            <StyledDivHeaderRow {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column, colIdx) => (
-                <StyledDivContentCell
-                  style={{
-                    width: columns[colIdx].width,
-                  }}
-                  {...column.getHeaderProps()}>
-                  <StyledDivContentCellLabel {...column.getSortByToggleProps()}>
-                    <span>{column.render('Header')}</span>
-                    {column.isSorted &&
-                      (column.isSortedDesc ? (
-                        <ArrowDropDownIcon fontSize='small' />
-                      ) : (
-                        <ArrowDropUpIcon fontSize='small' />
-                      ))}
-                  </StyledDivContentCellLabel>
-                  {column.canFilter && <Box sx={{ mt: 1 }}>{column.render('Filter')}</Box>}
-                </StyledDivContentCell>
-              ))}
-            </StyledDivHeaderRow>
-          ))}
-          {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-            let rowIdx = virtualItem.index;
-            const row = page[rowIdx];
-            prepareRow(row);
-
-            return (
-              <StyledDivContentRow
-                onDoubleClick={() => props.onRowClick && props.onRowClick(row.original)}
-                style={{
-                  cursor: props.onRowClick ? 'pointer' : '',
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-                data-row-idx={rowIdx}
-                {...row.getRowProps()}>
-                {row.cells.map((cell, colIdx) => {
-                  let dropdownContent: any;
-                  if (colIdx === 0 && targetRowContextOptions.length > 0) {
-                    dropdownContent = (
-                      <DropdownMenu
-                        id={`data-table-row-dropdown-${rowIdx}`}
-                        options={targetRowContextOptions}
-                        onToggle={(newOpen) => {
-                          if (newOpen) {
-                            setOpenContextMenuRowIdx(rowIdx);
-                          } else {
-                            setOpenContextMenuRowIdx(-1);
-                          }
-                        }}
-                        maxHeight='400px'
-                        anchorEl={anchorEl}
-                        open={openContextMenuRowIdx === rowIdx}
-                      />
-                    );
-                  }
-                  return (
-                    <StyledDivContentCell
-                      style={{
-                        width: columns[colIdx].width,
-                      }}
-                      {...cell.getCellProps()}>
-                      {dropdownContent}
-                      {cell.render('Cell')}
-                    </StyledDivContentCell>
-                  );
-                })}
-              </StyledDivContentRow>
-            );
-          })}
-        </StyledDivContainer>
-        {!page ||
-          (page.length === 0 && (
-            <Box sx={{ paddingInline: 2, paddingBlock: 2 }}>
-              There is no data in the query with matching filters.
-            </Box>
-          ))}
-      </Box>
-    </>
-  );
-}
-
 export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
   const { data } = props;
+
+  let hasRawJson = useMemo(() => {
+    for(const value of data){
+      for(const columnValue of Object.values(value)){
+        if (typeof columnValue === 'object' && columnValue !== null) {
+          return true;
+        }
+
+      }
+    }
+
+    return false;
+  }, [data]);
 
   const columns = useMemo(() => {
     const newColumnNames = new Set<string>();
@@ -354,6 +83,8 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
             columnValue = 'true';
           } else if (columnValue === false) {
             columnValue = 'false';
+          } else if (typeof columnValue === 'object') {
+            columnValue = JSON.stringify(columnValue);
           }
 
           const html = document.createElement('p');
@@ -363,41 +94,13 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
         Cell: (data: any, a, b, c) => {
           const columnValue = data.row.original[columnName];
           if (columnValue === null) {
-            return (
-              <Chip
-                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
-                size='small'
-                color='warning'
-                label='null'
-              />
-            );
+            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='info' label='null' />;
           } else if (columnValue === undefined) {
-            return (
-              <Chip
-                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
-                size='small'
-                color='warning'
-                label='undefined'
-              />
-            );
+            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='default' label='undefined' />;
           } else if (columnValue === true || columnValue?.toString()?.toLowerCase() === 'true') {
-            return (
-              <Chip
-                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
-                size='small'
-                color='success'
-                label='true'
-              />
-            );
+            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='success' label='true' />;
           } else if (columnValue === false || columnValue?.toString()?.toLowerCase() === 'false') {
-            return (
-              <Chip
-                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
-                size='small'
-                color='error'
-                label='false'
-              />
-            );
+            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='error' label='false' />;
           } else if (typeof columnValue === 'number') {
             return <pre style={{ textTransform: 'uppercase' }}>{columnValue}</pre>;
           } else if (typeof columnValue === 'object') {
@@ -421,5 +124,10 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
     });
   }, [data]);
 
-  return <DataTable {...props} columns={columns} />;
+  if(hasRawJson){
+    return <LegacyDataTable {...props} columns={columns} />;
+  }
+  return <ModernDataTable {...props} columns={columns} />;
 }
+
+export default LegacyDataTable;

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -1,19 +1,10 @@
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
-import Box from '@mui/material/Box';
-import { styled } from '@mui/material/styles';
-import Table from '@mui/material/Table';
-import TextField from '@mui/material/TextField';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { useFilters, useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
-import DropdownMenu from 'src/frontend/components/DropdownMenu';
-import { useTablePageSize } from 'src/frontend/hooks/useSetting';
-import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
 import Chip from '@mui/material/Chip';
+import Table from '@mui/material/Table';
+import { useMemo } from 'react';
 import LegacyDataTable from 'src/frontend/components/DataTable/LegacyDataTable';
 import ModernDataTable from 'src/frontend/components/DataTable/ModernDataTable';
+import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
+import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
 
 export type DataTableProps = {
   columns: any[];
@@ -40,12 +31,11 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
   const { data } = props;
 
   let hasRawJson = useMemo(() => {
-    for(const value of data){
-      for(const columnValue of Object.values(value)){
+    for (const value of data) {
+      for (const columnValue of Object.values(value)) {
         if (typeof columnValue === 'object' && columnValue !== null) {
           return true;
         }
-
       }
     }
 
@@ -94,13 +84,41 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
         Cell: (data: any, a, b, c) => {
           const columnValue = data.row.original[columnName];
           if (columnValue === null) {
-            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='info' label='null' />;
+            return (
+              <Chip
+                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                size='small'
+                color='info'
+                label='null'
+              />
+            );
           } else if (columnValue === undefined) {
-            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='default' label='undefined' />;
+            return (
+              <Chip
+                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                size='small'
+                color='default'
+                label='undefined'
+              />
+            );
           } else if (columnValue === true || columnValue?.toString()?.toLowerCase() === 'true') {
-            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='success' label='true' />;
+            return (
+              <Chip
+                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                size='small'
+                color='success'
+                label='true'
+              />
+            );
           } else if (columnValue === false || columnValue?.toString()?.toLowerCase() === 'false') {
-            return <Chip sx={{ textTransform: 'uppercase', fontStyle: 'italic' }} size='small' color='error' label='false' />;
+            return (
+              <Chip
+                sx={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                size='small'
+                color='error'
+                label='false'
+              />
+            );
           } else if (typeof columnValue === 'number') {
             return <pre style={{ textTransform: 'uppercase' }}>{columnValue}</pre>;
           } else if (typeof columnValue === 'object') {
@@ -124,7 +142,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
     });
   }, [data]);
 
-  if(hasRawJson){
+  if (hasRawJson) {
     return <LegacyDataTable {...props} columns={columns} />;
   }
   return <ModernDataTable {...props} columns={columns} />;


### PR DESCRIPTION
- Bring legacy data table to support dynamic values in MongoDB and other schema-less DB Engines. Because the react virtual (virtualizer) do not work well with dynamic nature of arbitrary JSON blob.
- Added global search for legacy table.
- Added inline per column search for legacy table.
- Added sorting for legacy table.

![image](https://user-images.githubusercontent.com/3792401/182197819-6abd0c16-eea0-4e87-a605-d53bd595b617.png)
