### PR TITLE
Support mysql / sqlalchemy / python code snippet and support MariaDB

### DIFF
--- a/src/frontend/components/DropdownButton/index.tsx
+++ b/src/frontend/components/DropdownButton/index.tsx
@@ -85,7 +85,7 @@ export default function DropdownButton(props: DropdownButtonProps): JSX.Element 
             content = (
               <MenuItem onClick={(event) => handleMenuItemClick(event, index)}>
                 {!option.startIcon ? null : <ListItemIcon>{option.startIcon}</ListItemIcon>}
-                <ListItemText sx={{ textTransform: 'capitalize'}}>{option.label}</ListItemText>
+                <ListItemText sx={{ textTransform: 'capitalize' }}>{option.label}</ListItemText>
               </MenuItem>
             );
           }

--- a/src/frontend/components/DropdownButton/index.tsx
+++ b/src/frontend/components/DropdownButton/index.tsx
@@ -85,7 +85,7 @@ export default function DropdownButton(props: DropdownButtonProps): JSX.Element 
             content = (
               <MenuItem onClick={(event) => handleMenuItemClick(event, index)}>
                 {!option.startIcon ? null : <ListItemIcon>{option.startIcon}</ListItemIcon>}
-                <ListItemText>{option.label}</ListItemText>
+                <ListItemText sx={{ textTransform: 'capitalize'}}>{option.label}</ListItemText>
               </MenuItem>
             );
           }

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1250,7 +1250,7 @@ export default function MissionControl() {
             await prompt({
               title: `Sample Code Snippet`,
               message: `LanguageMode = ${language}`,
-              value: codeSnippet,
+              value: codeSnippet || 'Not Supported Yet',
               isLongPrompt: true,
               readonly: true,
               languageMode: language,


### PR DESCRIPTION
Part of #572

- Support mysql / sqlalchemy / python code snippet
- Capitalize text for the language mode
- Added `Not Supported Yet` label for language / database that we don't have code snippet for.