### PR TITLE
Fixed issue where `tableId` is not persisted when reloaded

### DIFF
--- a/src/common/Endpoints.ts
+++ b/src/common/Endpoints.ts
@@ -298,6 +298,7 @@ export function setUpDataEndpoints(anExpressAppContext?: Express) {
         name: req.body.name,
         connectionId: req.body?.connectionId,
         databaseId: req.body?.databaseId,
+        tableId: req.body?.tableId,
         sql: req.body?.sql,
       }),
     );


### PR DESCRIPTION
- Fixed issue where `tableId` is not persisted when reloaded