### PR TITLE
Enhance Connection helper improvement to use `restOfConnectionString` for azure cosmosdb and table storage.

### DIFF
--- a/src/common/adapters/CassandraDataAdapter/scripts.ts
+++ b/src/common/adapters/CassandraDataAdapter/scripts.ts
@@ -71,8 +71,7 @@ export function getInsert(
   const columnString = input.columns.map((col) => col.name).join(',\n');
   const insertValueString = input.columns.map((col) => {
     let valToUse: string | null = '';
-    console.log(col.name, value?.[col.name]);
-    if (col.name === 'meeting_promoted') debugger;
+
     if (value) {
       if (value?.[col.name] === null) {
         valToUse = null;

--- a/src/frontend/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/frontend/components/ConnectionForm/ConnectionHint.tsx
@@ -82,31 +82,33 @@ export default function ConnectionHint(props: ConnectionHintProps): JSX.Element 
 
   return (
     <List sx={{ bgcolor: 'background.paper', overflow: 'hidden', wordBreak: 'break-all' }}>
-      {SUPPORTED_DIALECTS.sort((a,b) => getDialectName(a).localeCompare(getDialectName(b))).map((dialect) => {
-        const onApplyThisConnectionHint = () =>
-          props.onChange(dialect, getSampleConnectionString(dialect));
+      {SUPPORTED_DIALECTS.sort((a, b) => getDialectName(a).localeCompare(getDialectName(b))).map(
+        (dialect) => {
+          const onApplyThisConnectionHint = () =>
+            props.onChange(dialect, getSampleConnectionString(dialect));
 
-        return (
-          <ListItem key={dialect}>
-            <ListItemAvatar>
-              <Avatar>
-                <ConnectionTypeIcon dialect={dialect} status='online' />
-              </Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary={
-                <Link
-                  underline='hover'
-                  onClick={onApplyThisConnectionHint}
-                  sx={{ textTransform: 'uppercase', fontWeight: 'bold' }}>
-                  {getDialectName(dialect)}
-                </Link>
-              }
-              secondary={getSampleConnectionString(dialect)}
-            />
-          </ListItem>
-        );
-      })}
+          return (
+            <ListItem key={dialect}>
+              <ListItemAvatar>
+                <Avatar>
+                  <ConnectionTypeIcon dialect={dialect} status='online' />
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText
+                primary={
+                  <Link
+                    underline='hover'
+                    onClick={onApplyThisConnectionHint}
+                    sx={{ textTransform: 'uppercase', fontWeight: 'bold' }}>
+                    {getDialectName(dialect)}
+                  </Link>
+                }
+                secondary={getSampleConnectionString(dialect)}
+              />
+            </ListItem>
+          );
+        },
+      )}
       {bookmarkedConnectionsDom}
     </List>
   );

--- a/src/frontend/components/ConnectionForm/ConnectionHint.tsx
+++ b/src/frontend/components/ConnectionForm/ConnectionHint.tsx
@@ -82,7 +82,7 @@ export default function ConnectionHint(props: ConnectionHintProps): JSX.Element 
 
   return (
     <List sx={{ bgcolor: 'background.paper', overflow: 'hidden', wordBreak: 'break-all' }}>
-      {SUPPORTED_DIALECTS.map((dialect) => {
+      {SUPPORTED_DIALECTS.sort((a,b) => getDialectName(a).localeCompare(getDialectName(b))).map((dialect) => {
         const onApplyThisConnectionHint = () =>
           props.onChange(dialect, getSampleConnectionString(dialect));
 

--- a/src/frontend/components/ConnectionForm/index.tsx
+++ b/src/frontend/components/ConnectionForm/index.tsx
@@ -256,7 +256,7 @@ function MainConnectionForm(props: MainConnectionFormProps): JSX.Element | null 
             selectCommand({
               event: 'clientEvent/showConnectionHelper',
               data: {
-                scheme: parsedConnectionProps?.scheme,
+                scheme: parsedConnectionProps?.scheme || connection.connection.match(/^[a-z0-9]+/)?.[0] || 0,
                 username: parsedConnectionProps?.username,
                 password: parsedConnectionProps?.password,
                 host: parsedConnectionProps?.hosts[0]?.host,

--- a/src/frontend/components/ConnectionForm/index.tsx
+++ b/src/frontend/components/ConnectionForm/index.tsx
@@ -184,6 +184,7 @@ function MainConnectionForm(props: MainConnectionFormProps): JSX.Element | null 
   };
 
   const parsedConnectionProps = BaseDataAdapter.getConnectionParameters(connection.connection);
+  const restOfConnectionString = connection.connection.replace(/[a-z0-9+]:\/\/+/,'');
 
   const onApplyConnectionHint = (dialect, connection) => {
     props.setName(`${dialect} Connection - ${new Date().toLocaleDateString()}`);
@@ -260,6 +261,7 @@ function MainConnectionForm(props: MainConnectionFormProps): JSX.Element | null 
                 password: parsedConnectionProps?.password,
                 host: parsedConnectionProps?.hosts[0]?.host,
                 port: parsedConnectionProps?.hosts[0]?.port,
+                restOfConnectionString,
                 onApply: (newConnection: string) => {
                   props.setConnection(newConnection);
                 },

--- a/src/frontend/components/ConnectionForm/index.tsx
+++ b/src/frontend/components/ConnectionForm/index.tsx
@@ -184,7 +184,7 @@ function MainConnectionForm(props: MainConnectionFormProps): JSX.Element | null 
   };
 
   const parsedConnectionProps = BaseDataAdapter.getConnectionParameters(connection.connection);
-  const restOfConnectionString = connection.connection.replace(/[a-z0-9+]:\/\/+/,'');
+  const restOfConnectionString = connection.connection.replace(/[a-z0-9+]:\/\/+/, '');
 
   const onApplyConnectionHint = (dialect, connection) => {
     props.setName(`${dialect} Connection - ${new Date().toLocaleDateString()}`);
@@ -256,7 +256,10 @@ function MainConnectionForm(props: MainConnectionFormProps): JSX.Element | null 
             selectCommand({
               event: 'clientEvent/showConnectionHelper',
               data: {
-                scheme: parsedConnectionProps?.scheme || connection.connection.match(/^[a-z0-9]+/)?.[0] || 0,
+                scheme:
+                  parsedConnectionProps?.scheme ||
+                  connection.connection.match(/^[a-z0-9]+/)?.[0] ||
+                  0,
                 username: parsedConnectionProps?.username,
                 password: parsedConnectionProps?.password,
                 host: parsedConnectionProps?.hosts[0]?.host,

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import { useState } from 'react';
@@ -47,12 +48,20 @@ export default function ConnectionHelper(props: ConnectionHelper) {
     case 'cosmosdb':
     connection += `${value.restOfConnectionString}`;
 
-    debugger
+    let label = 'Connection String';
+    switch(value.scheme){
+      case 'aztable':
+        label = 'Azure Table Storage Connection String';
+        break;
+      case 'cosmosdb':
+        label = 'CosmosDB Primary Connection String';
+        break;
+    }
 
     formDom= <>
       <div className='FormInput__Row'>
         <TextField
-          label='Primary Connection String'
+          label={label}
           value={value.restOfConnectionString}
           onChange={(e) => onChange('restOfConnectionString', e.target.value)}
           required
@@ -147,11 +156,11 @@ export default function ConnectionHelper(props: ConnectionHelper) {
           fullWidth={true}
         />
       </div>
-      <div>
+      <Box sx={{display: 'flex', justifyContent:'end'}}>
         <Button type='submit' sx={{ ml: 'auto' }}>
           Apply
         </Button>
-      </div>
+      </Box>
     </form>
   );
 }

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -43,85 +43,89 @@ export default function ConnectionHelper(props: ConnectionHelper) {
   const onGenerateConnectionString = () => props.onChange(connection);
 
   let formDom;
-  switch(value.scheme){
+  switch (value.scheme) {
     case 'aztable':
     case 'cosmosdb':
-    connection += `${value.restOfConnectionString}`;
+      connection += `${value.restOfConnectionString}`;
 
-    let label = 'Connection String';
-    switch(value.scheme){
-      case 'aztable':
-        label = 'Azure Table Storage Connection String';
-        break;
-      case 'cosmosdb':
-        label = 'CosmosDB Primary Connection String';
-        break;
-    }
+      let label = 'Connection String';
+      switch (value.scheme) {
+        case 'aztable':
+          label = 'Azure Table Storage Connection String';
+          break;
+        case 'cosmosdb':
+          label = 'CosmosDB Primary Connection String';
+          break;
+      }
 
-    formDom= <>
-      <div className='FormInput__Row'>
-        <TextField
-          label={label}
-          value={value.restOfConnectionString}
-          onChange={(e) => onChange('restOfConnectionString', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-    </>
+      formDom = (
+        <>
+          <div className='FormInput__Row'>
+            <TextField
+              label={label}
+              value={value.restOfConnectionString}
+              onChange={(e) => onChange('restOfConnectionString', e.target.value)}
+              required
+              size='small'
+              fullWidth={true}
+            />
+          </div>
+        </>
+      );
       break;
     default:
-    if (value.username && value.password) {
-      connection += `${value.username}:${value.password}`;
-    }
-    connection += `@${value.host}`;
-    if (value.port) {
-      connection += `${value.port}`;
-    }
+      if (value.username && value.password) {
+        connection += `${value.username}:${value.password}`;
+      }
+      connection += `@${value.host}`;
+      if (value.port) {
+        connection += `${value.port}`;
+      }
 
-    formDom = <>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Username'
-          value={value.username}
-          onChange={(e) => onChange('username', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Password'
-          value={value.password}
-          onChange={(e) => onChange('password', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Host'
-          value={value.host}
-          onChange={(e) => onChange('host', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Port'
-          value={value.port}
-          onChange={(e) => onChange('port', e.target.value)}
-          size='small'
-          fullWidth={true}
-          type='number'
-        />
-      </div>
-      </>
+      formDom = (
+        <>
+          <div className='FormInput__Row'>
+            <TextField
+              label='Username'
+              value={value.username}
+              onChange={(e) => onChange('username', e.target.value)}
+              required
+              size='small'
+              fullWidth={true}
+            />
+          </div>
+          <div className='FormInput__Row'>
+            <TextField
+              label='Password'
+              value={value.password}
+              onChange={(e) => onChange('password', e.target.value)}
+              required
+              size='small'
+              fullWidth={true}
+            />
+          </div>
+          <div className='FormInput__Row'>
+            <TextField
+              label='Host'
+              value={value.host}
+              onChange={(e) => onChange('host', e.target.value)}
+              required
+              size='small'
+              fullWidth={true}
+            />
+          </div>
+          <div className='FormInput__Row'>
+            <TextField
+              label='Port'
+              value={value.port}
+              onChange={(e) => onChange('port', e.target.value)}
+              size='small'
+              fullWidth={true}
+              type='number'
+            />
+          </div>
+        </>
+      );
       break;
   }
 
@@ -133,7 +137,7 @@ export default function ConnectionHelper(props: ConnectionHelper) {
         onGenerateConnectionString();
       }}>
       <div className='FormInput__Row'>
-                <Select
+        <Select
           required
           onChange={(newScheme) => onChange('scheme', newScheme)}
           value={value.scheme}>
@@ -156,7 +160,7 @@ export default function ConnectionHelper(props: ConnectionHelper) {
           fullWidth={true}
         />
       </div>
-      <Box sx={{display: 'flex', justifyContent:'end'}}>
+      <Box sx={{ display: 'flex', justifyContent: 'end' }}>
         <Button type='submit' sx={{ ml: 'auto' }}>
           Apply
         </Button>

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -10,14 +10,10 @@ type ConnectionHelperFormInputs = {
   password: string;
   host: string;
   port: string;
+  restOfConnectionString: string;
 };
 
-type ConnectionHelper = {
-  scheme: string;
-  username: string;
-  password: string;
-  host: string;
-  port: string;
+type ConnectionHelper = ConnectionHelperFormInputs & {
   onChange: (newConnection: string) => void;
 };
 
@@ -28,15 +24,10 @@ export default function ConnectionHelper(props: ConnectionHelper) {
     password: props.password || '',
     host: props.host || '',
     port: props.port || '',
+    restOfConnectionString: props.restOfConnectionString || '',
   });
+
   let connection = `${value.scheme}://`;
-  if (value.username && value.password) {
-    connection += `${value.username}:${value.password}`;
-  }
-  connection += `@${value.host}`;
-  if (value.port) {
-    connection += `${value.port}`;
-  }
 
   const onChange = (fieldKey: string, fieldValue: string) => {
     const newValue = {
@@ -50,6 +41,81 @@ export default function ConnectionHelper(props: ConnectionHelper) {
   // construct the final
   const onGenerateConnectionString = () => props.onChange(connection);
 
+  let formDom;
+  switch(value.scheme){
+    case 'aztable':
+    case 'cosmosdb':
+    connection += `${value.restOfConnectionString}`;
+
+    debugger
+
+    formDom= <>
+      <div className='FormInput__Row'>
+        <TextField
+          label='Primary Connection String'
+          value={value.restOfConnectionString}
+          onChange={(e) => onChange('restOfConnectionString', e.target.value)}
+          required
+          size='small'
+          fullWidth={true}
+        />
+      </div>
+    </>
+      break;
+    default:
+    if (value.username && value.password) {
+      connection += `${value.username}:${value.password}`;
+    }
+    connection += `@${value.host}`;
+    if (value.port) {
+      connection += `${value.port}`;
+    }
+
+    formDom = <>
+      <div className='FormInput__Row'>
+        <TextField
+          label='Username'
+          value={value.username}
+          onChange={(e) => onChange('username', e.target.value)}
+          required
+          size='small'
+          fullWidth={true}
+        />
+      </div>
+      <div className='FormInput__Row'>
+        <TextField
+          label='Password'
+          value={value.password}
+          onChange={(e) => onChange('password', e.target.value)}
+          required
+          size='small'
+          fullWidth={true}
+        />
+      </div>
+      <div className='FormInput__Row'>
+        <TextField
+          label='Host'
+          value={value.host}
+          onChange={(e) => onChange('host', e.target.value)}
+          required
+          size='small'
+          fullWidth={true}
+        />
+      </div>
+      <div className='FormInput__Row'>
+        <TextField
+          label='Port'
+          value={value.port}
+          onChange={(e) => onChange('port', e.target.value)}
+          size='small'
+          fullWidth={true}
+          type='number'
+        />
+      </div>
+      </>
+      break;
+  }
+
   return (
     <form
       className='FormInput__Container'
@@ -58,7 +124,7 @@ export default function ConnectionHelper(props: ConnectionHelper) {
         onGenerateConnectionString();
       }}>
       <div className='FormInput__Row'>
-        <Select
+                <Select
           required
           onChange={(newScheme) => onChange('scheme', newScheme)}
           value={value.scheme}>
@@ -70,46 +136,7 @@ export default function ConnectionHelper(props: ConnectionHelper) {
           ))}
         </Select>
       </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Username'
-          defaultValue={value.username}
-          onChange={(e) => onChange('username', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Password'
-          defaultValue={value.password}
-          onChange={(e) => onChange('password', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Host'
-          defaultValue={value.host}
-          onChange={(e) => onChange('host', e.target.value)}
-          required
-          size='small'
-          fullWidth={true}
-        />
-      </div>
-      <div className='FormInput__Row'>
-        <TextField
-          label='Port'
-          defaultValue={value.port}
-          onChange={(e) => onChange('port', e.target.value)}
-          size='small'
-          fullWidth={true}
-          type='number'
-        />
-      </div>
+      {formDom}
       <div className='FormInput__Row'>
         <TextField
           label='Generated Connection String'

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1046,7 +1046,8 @@ export default function MissionControl() {
 
         case 'clientEvent/showConnectionHelper':
           if (command.data) {
-            const { scheme, username, password, host, port, restOfConnectionString, onApply } = command.data as any;
+            const { scheme, username, password, host, port, restOfConnectionString, onApply } =
+              command.data as any;
 
             const onApplyConnectionHelper = (newConnectionString: string) => {
               dismissDialog();

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1046,7 +1046,7 @@ export default function MissionControl() {
 
         case 'clientEvent/showConnectionHelper':
           if (command.data) {
-            const { scheme, username, password, host, port, onApply } = command.data as any;
+            const { scheme, username, password, host, port, restOfConnectionString, onApply } = command.data as any;
 
             const onApplyConnectionHelper = (newConnectionString: string) => {
               dismissDialog();
@@ -1064,6 +1064,7 @@ export default function MissionControl() {
                   password={password}
                   host={host}
                   port={port}
+                  restOfConnectionString={restOfConnectionString}
                 />
               ),
               showCloseButton: true,


### PR DESCRIPTION
- Use Rest of Connection String for Azure Table and CosmosDB.
- Fixed an issue where scheme is not parsed when the parser can't detect a proper URL.
- Sort connection in connection hint by name.
- Removed `debugger`.

#### Screenshots
![image](https://user-images.githubusercontent.com/3792401/183528817-5d256ece-8820-496e-b35e-72bec83a0066.png)
![image](https://user-images.githubusercontent.com/3792401/183528913-2aed7669-a05c-423a-9eee-0575c6a555d6.png)
