### PR TITLE
Meta data driven for Added connection helper form interface

### DIFF
--- a/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
+++ b/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
@@ -377,6 +377,12 @@ export class ConcreteDataScripts extends BaseDataScript {
     return 'javascript';
   }
 
+  getConnectionFormInputs() {
+    return [
+      ['restOfConnectionString', 'Azure CosmosDB Primary Connection String'],
+    ]
+  }
+
   supportMigration() {
     return true;
   }

--- a/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
+++ b/src/common/adapters/AzureCosmosDataAdapter/scripts.ts
@@ -378,9 +378,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   getConnectionFormInputs() {
-    return [
-      ['restOfConnectionString', 'Azure CosmosDB Primary Connection String'],
-    ]
+    return [['restOfConnectionString', 'Azure CosmosDB Primary Connection String']];
   }
 
   supportMigration() {

--- a/src/common/adapters/AzureTableStorageAdapter/scripts.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/scripts.ts
@@ -269,9 +269,7 @@ export class ConcreteDataScripts extends BaseDataScript {
   dialects = ['aztable'];
 
   getConnectionFormInputs() {
-    return [
-      ['restOfConnectionString', 'Azure Table Storage Connection String'],
-    ]
+    return [['restOfConnectionString', 'Azure Table Storage Connection String']];
   }
 
   getIsTableIdRequiredForQuery() {

--- a/src/common/adapters/AzureTableStorageAdapter/scripts.ts
+++ b/src/common/adapters/AzureTableStorageAdapter/scripts.ts
@@ -268,6 +268,12 @@ export function getCreateDatabaseTable(
 export class ConcreteDataScripts extends BaseDataScript {
   dialects = ['aztable'];
 
+  getConnectionFormInputs() {
+    return [
+      ['restOfConnectionString', 'Azure Table Storage Connection String'],
+    ]
+  }
+
   getIsTableIdRequiredForQuery() {
     return true;
   }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -30,7 +30,7 @@ export default abstract class BaseDataScript implements IDataScript {
       ['password', 'Password'],
       ['host', 'Host'],
       ['port', 'Port'],
-    ]
+    ];
   }
 
   getIsTableIdRequiredForQuery() {

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -24,6 +24,15 @@ export default abstract class BaseDataScript implements IDataScript {
     return undefined;
   }
 
+  getConnectionFormInputs() {
+    return [
+      ['username', 'Username'],
+      ['password', 'Password'],
+      ['host', 'Host'],
+      ['port', 'Port'],
+    ]
+  }
+
   getIsTableIdRequiredForQuery() {
     return false;
   }

--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -29,7 +29,7 @@ export default abstract class BaseDataScript implements IDataScript {
       ['username', 'Username'],
       ['password', 'Password'],
       ['host', 'Host'],
-      ['port', 'Port'],
+      ['port', 'Port', 'optional'],
     ];
   }
 

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -69,6 +69,10 @@ export function getDialectType(connection: string, dialect?: string) {
   return _getImplementation(dialect)?.getDialectType(connection);
 }
 
+export function getConnectionFormInputs(dialect?: string) {
+  return _getImplementation(dialect)?.getConnectionFormInputs() || [];
+}
+
 export function consolidateDialects(res: string[], script: BaseDataScript) {
   for (const dialect of script.dialects) {
     res.push(dialect);

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -4,6 +4,7 @@ export default interface IDataScript {
   dialects?: SqluiCore.Dialect[] | string[];
 
   getDialectType: (connectionString: string) => SqluiCore.Dialect | undefined;
+  getConnectionFormInputs: () => string[][];
 
   // misc methods
   isDialectSupported: (targetDialect?: string) => boolean;

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -2,9 +2,8 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import { useState } from 'react';
-import { SUPPORTED_DIALECTS } from 'src/common/adapters/DataScriptFactory';
+import { getConnectionFormInputs, SUPPORTED_DIALECTS } from 'src/common/adapters/DataScriptFactory';
 import Select from 'src/frontend/components/Select';
-import { getConnectionFormInputs } from 'src/common/adapters/DataScriptFactory';
 
 type ConnectionHelperFormInputs = {
   scheme: string;
@@ -17,7 +16,7 @@ type ConnectionHelperFormInputs = {
 
 type ConnectionHelperProps = ConnectionHelperFormInputs & {
   onChange: (newConnection: string) => void;
-  onClose:() => void;
+  onClose: () => void;
 };
 
 export default function ConnectionHelper(props: ConnectionHelperProps) {
@@ -33,7 +32,7 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
   const formInputs = getConnectionFormInputs(value.scheme);
 
   let connection = `${value.scheme}://`;
-  if(formInputs.length === 1){
+  if (formInputs.length === 1) {
     connection += `${value[formInputs[0][0]]}`;
   } else {
     if (value.username && value.password) {
@@ -57,9 +56,15 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
   // construct the final
   const onApply = () => props.onChange(connection);
 
-  const formDom = formInputs.length === 0 ? <div className='FormInput__Row'>This database scheme is not supported by the connection helper</div>
-  : formInputs.map(([inputKey, inputLabel]) => {
-    return <div className='FormInput__Row'>
+  const formDom =
+    formInputs.length === 0 ? (
+      <div className='FormInput__Row'>
+        This database scheme is not supported by the connection helper
+      </div>
+    ) : (
+      formInputs.map(([inputKey, inputLabel]) => {
+        return (
+          <div className='FormInput__Row'>
             <TextField
               label={inputLabel}
               value={value[inputKey]}
@@ -69,7 +74,9 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
               fullWidth={true}
             />
           </div>
-  })
+        );
+      })
+    );
 
   return (
     <form

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -40,7 +40,7 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
     }
     connection += `@${value.host}`;
     if (value.port) {
-      connection += `${value.port}`;
+      connection += `:${value.port}`;
     }
   }
 
@@ -62,14 +62,15 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
         This database scheme is not supported by the connection helper
       </div>
     ) : (
-      formInputs.map(([inputKey, inputLabel]) => {
+      formInputs.map(([inputKey, inputLabel, optionalFlag]) => {
+        const isRequired = optionalFlag !== 'optional'
         return (
           <div className='FormInput__Row'>
             <TextField
               label={inputLabel}
               value={value[inputKey]}
               onChange={(e) => onChange(inputKey, e.target.value)}
-              required
+              required={isRequired}
               size='small'
               fullWidth={true}
             />

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -36,7 +36,7 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
     connection += `${value[formInputs[0][0]]}`;
   } else {
     if (value.username && value.password) {
-      connection += `${value.username}:${value.password}`;
+      connection += `${encodeURIComponent(value.username)}:${encodeURIComponent(value.password)}`;
     }
     connection += `@${value.host}`;
     if (value.port) {

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -63,7 +63,7 @@ export default function ConnectionHelper(props: ConnectionHelperProps) {
       </div>
     ) : (
       formInputs.map(([inputKey, inputLabel, optionalFlag]) => {
-        const isRequired = optionalFlag !== 'optional'
+        const isRequired = optionalFlag !== 'optional';
         return (
           <div className='FormInput__Row'>
             <TextField

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -4,6 +4,7 @@ import TextField from '@mui/material/TextField';
 import { useState } from 'react';
 import { SUPPORTED_DIALECTS } from 'src/common/adapters/DataScriptFactory';
 import Select from 'src/frontend/components/Select';
+import { getConnectionFormInputs } from 'src/common/adapters/DataScriptFactory';
 
 type ConnectionHelperFormInputs = {
   scheme: string;
@@ -14,11 +15,12 @@ type ConnectionHelperFormInputs = {
   restOfConnectionString: string;
 };
 
-type ConnectionHelper = ConnectionHelperFormInputs & {
+type ConnectionHelperProps = ConnectionHelperFormInputs & {
   onChange: (newConnection: string) => void;
+  onClose:() => void;
 };
 
-export default function ConnectionHelper(props: ConnectionHelper) {
+export default function ConnectionHelper(props: ConnectionHelperProps) {
   const [value, setValue] = useState<ConnectionHelperFormInputs>({
     scheme: props.scheme || '',
     username: props.username || '',
@@ -28,7 +30,20 @@ export default function ConnectionHelper(props: ConnectionHelper) {
     restOfConnectionString: props.restOfConnectionString || '',
   });
 
+  const formInputs = getConnectionFormInputs(value.scheme);
+
   let connection = `${value.scheme}://`;
+  if(formInputs.length === 1){
+    connection += `${value[formInputs[0][0]]}`;
+  } else {
+    if (value.username && value.password) {
+      connection += `${value.username}:${value.password}`;
+    }
+    connection += `@${value.host}`;
+    if (value.port) {
+      connection += `${value.port}`;
+    }
+  }
 
   const onChange = (fieldKey: string, fieldValue: string) => {
     const newValue = {
@@ -40,101 +55,28 @@ export default function ConnectionHelper(props: ConnectionHelper) {
   };
 
   // construct the final
-  const onGenerateConnectionString = () => props.onChange(connection);
+  const onApply = () => props.onChange(connection);
 
-  let formDom;
-  switch (value.scheme) {
-    case 'aztable':
-    case 'cosmosdb':
-      connection += `${value.restOfConnectionString}`;
-
-      let label = 'Connection String';
-      switch (value.scheme) {
-        case 'aztable':
-          label = 'Azure Table Storage Connection String';
-          break;
-        case 'cosmosdb':
-          label = 'CosmosDB Primary Connection String';
-          break;
-      }
-
-      formDom = (
-        <>
-          <div className='FormInput__Row'>
+  const formDom = formInputs.length === 0 ? <div className='FormInput__Row'>This database scheme is not supported by the connection helper</div>
+  : formInputs.map(([inputKey, inputLabel]) => {
+    return <div className='FormInput__Row'>
             <TextField
-              label={label}
-              value={value.restOfConnectionString}
-              onChange={(e) => onChange('restOfConnectionString', e.target.value)}
+              label={inputLabel}
+              value={value[inputKey]}
+              onChange={(e) => onChange(inputKey, e.target.value)}
               required
               size='small'
               fullWidth={true}
             />
           </div>
-        </>
-      );
-      break;
-    default:
-      if (value.username && value.password) {
-        connection += `${value.username}:${value.password}`;
-      }
-      connection += `@${value.host}`;
-      if (value.port) {
-        connection += `${value.port}`;
-      }
-
-      formDom = (
-        <>
-          <div className='FormInput__Row'>
-            <TextField
-              label='Username'
-              value={value.username}
-              onChange={(e) => onChange('username', e.target.value)}
-              required
-              size='small'
-              fullWidth={true}
-            />
-          </div>
-          <div className='FormInput__Row'>
-            <TextField
-              label='Password'
-              value={value.password}
-              onChange={(e) => onChange('password', e.target.value)}
-              required
-              size='small'
-              fullWidth={true}
-            />
-          </div>
-          <div className='FormInput__Row'>
-            <TextField
-              label='Host'
-              value={value.host}
-              onChange={(e) => onChange('host', e.target.value)}
-              required
-              size='small'
-              fullWidth={true}
-            />
-          </div>
-          <div className='FormInput__Row'>
-            <TextField
-              label='Port'
-              value={value.port}
-              onChange={(e) => onChange('port', e.target.value)}
-              size='small'
-              fullWidth={true}
-              type='number'
-            />
-          </div>
-        </>
-      );
-      break;
-  }
+  })
 
   return (
     <form
       className='FormInput__Container'
       onSubmit={(e) => {
         e.preventDefault();
-        onGenerateConnectionString();
+        onApply();
       }}>
       <div className='FormInput__Row'>
         <Select
@@ -160,9 +102,12 @@ export default function ConnectionHelper(props: ConnectionHelper) {
           fullWidth={true}
         />
       </div>
-      <Box sx={{ display: 'flex', justifyContent: 'end' }}>
-        <Button type='submit' sx={{ ml: 'auto' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'end', gap: 2 }}>
+        <Button type='submit' variant='contained'>
           Apply
+        </Button>
+        <Button type='button' onClick={props.onClose}>
+          Cancel
         </Button>
       </Box>
     </form>

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1060,6 +1060,7 @@ export default function MissionControl() {
               message: (
                 <ConnectionHelper
                   onChange={onApplyConnectionHelper}
+                  onClose={dismissDialog}
                   scheme={scheme}
                   username={username}
                   password={password}

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1302,7 +1302,6 @@ export default function MissionControl() {
                 case 'java':
                   extension = 'java';
                   break;
-
               }
               if (extension) {
                 downloadText(
@@ -1408,7 +1407,6 @@ export default function MissionControl() {
 
           window.toggleElectronMenu(true, allMenuKeys);
           break;
-
       }
     }
   }
@@ -1449,7 +1447,6 @@ export default function MissionControl() {
               e.preventDefault();
             } catch (err) {}
             break;
-
         }
       }
     };
@@ -1512,7 +1509,6 @@ export default function MissionControl() {
               event: 'clientEvent/query/showNext',
             };
             break;
-
         }
       } else {
         // no modifier key
@@ -1522,7 +1518,6 @@ export default function MissionControl() {
               event: 'clientEvent/query/rename',
             };
             break;
-
         }
       }
 

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -839,6 +839,7 @@ export default function MissionControl() {
             case 'connection':
               await importConnection(rawImportMetaData);
               break;
+
             case 'query':
               await connectionQueries.onImportQuery(jsonRow);
               break;
@@ -1004,6 +1005,7 @@ export default function MissionControl() {
         case 'clientEvent/navigate':
           navigate(command.data as string);
           break;
+
         case 'clientEvent/showCommandPalette':
           onShowCommandPalette();
           break;
@@ -1107,26 +1109,31 @@ export default function MissionControl() {
             onDeleteConnection(command.data as SqluiCore.ConnectionProps);
           }
           break;
+
         case 'clientEvent/connection/refresh':
           if (command.data) {
             onRefreshConnection(command.data as SqluiCore.ConnectionProps);
           }
           break;
+
         case 'clientEvent/connection/duplicate':
           if (command.data) {
             onDuplicateConnection(command.data as SqluiCore.ConnectionProps);
           }
           break;
+
         case 'clientEvent/connection/export':
           if (command.data) {
             onExportConnection(command.data as SqluiCore.ConnectionProps);
           }
           break;
+
         case 'clientEvent/connection/select':
           if (command.data) {
             onSelectConnection(command.data as SqluiCore.ConnectionProps);
           }
           break;
+
         case 'clientEvent/connection/addToBookmark':
           if (command.data) {
             onAddConnectionToBookmark(command.data as SqluiCore.ConnectionProps);
@@ -1287,12 +1294,15 @@ export default function MissionControl() {
                 case 'javascript':
                   extension = 'js';
                   break;
+
                 case 'python':
                   extension = 'py';
                   break;
+
                 case 'java':
                   extension = 'java';
                   break;
+
               }
               if (extension) {
                 downloadText(
@@ -1328,16 +1338,15 @@ export default function MissionControl() {
             onShowRecordDetails(command.data, false);
           }
           break;
+
         case 'clientEvent/record/edit':
           if (command.data) {
             onShowRecordDetails(command.data, true);
           }
           break;
+
         case 'clientEvent/record/new':
           navigate('/record/new');
-          break;
-        case 'clientEvent/record/edit':
-          // TODO to be implemented
           break;
 
         // session commands
@@ -1386,6 +1395,7 @@ export default function MissionControl() {
 
           window.toggleElectronMenu(true, allMenuKeys);
           break;
+
         case 'clientEvent/session/delete':
           try {
             window.toggleElectronMenu(false, allMenuKeys);
@@ -1398,6 +1408,7 @@ export default function MissionControl() {
 
           window.toggleElectronMenu(true, allMenuKeys);
           break;
+
       }
     }
   }
@@ -1430,6 +1441,7 @@ export default function MissionControl() {
               e.preventDefault();
             } catch (err) {}
             break;
+
           case 'f':
             try {
               (document.querySelector('#result-box-search-input') as HTMLInputElement)?.focus();
@@ -1437,6 +1449,7 @@ export default function MissionControl() {
               e.preventDefault();
             } catch (err) {}
             break;
+
         }
       }
     };
@@ -1457,41 +1470,49 @@ export default function MissionControl() {
               event: 'clientEvent/showCommandPalette',
             };
             break;
+
           case 't':
             command = {
               event: 'clientEvent/query/new',
             };
             break;
+
           case 'o':
             command = {
               event: 'clientEvent/import',
             };
             break;
+
           case 's':
             command = {
               event: 'clientEvent/exportAll',
             };
             break;
+
           case 'n':
             command = {
               event: 'clientEvent/connection/new',
             };
             break;
+
           case 'w':
             command = {
               event: 'clientEvent/query/closeCurrentlySelected',
             };
             break;
+
           case '{':
             command = {
               event: 'clientEvent/query/showPrev',
             };
             break;
+
           case '}':
             command = {
               event: 'clientEvent/query/showNext',
             };
             break;
+
         }
       } else {
         // no modifier key
@@ -1501,6 +1522,7 @@ export default function MissionControl() {
               event: 'clientEvent/query/rename',
             };
             break;
+
         }
       }
 


### PR DESCRIPTION
- Use metadata to drive the connection helper form inputs.
- Make `port` optional
- EncodeURI component accordingly to make sure the inputs are properly escaped.