### PR TITLE
Optimize the layout for rendering of react-flow in relationship visualization to be stretch horizontally

### DIFF
--- a/src/frontend/views/RelationshipChartPage/index.tsx
+++ b/src/frontend/views/RelationshipChartPage/index.tsx
@@ -19,6 +19,7 @@ type MyNode = any;
 type MyEdge = any;
 
 const width = 200;
+
 const widthDelta = 10;
 const height = 80;
 const heightDelta = 25;
@@ -82,13 +83,13 @@ export default function RelationshipChartPage() {
             (edge) => edge.source === tableName && edge.target === tableColumn.referencedTableName,
           );
 
-          const newEdge = ({
+          const newEdge = {
             _label: `${tableColumn.name} => ${tableColumn.referencedTableName}.${tableColumn.referencedColumnName}`,
             id: `${tableName}.${tableColumn.name} => ${tableColumn.referencedTableName}.${tableColumn.referencedColumnName}`,
             source: tableName, // from
             target: tableColumn.referencedTableName, // to
             type: 'straight',
-          });
+          };
 
           mapNodeConnectionsCount[tableColumn.referencedTableName] =
             mapNodeConnectionsCount[tableColumn.referencedTableName] || 0;
@@ -112,8 +113,8 @@ export default function RelationshipChartPage() {
       const count = mapNodeConnectionsCount[tableName];
 
       let foundIdx = countGroups.indexOf(count);
-      if(foundIdx === -1){
-        if(nodesHasEdge.has(tableName)){
+      if (foundIdx === -1) {
+        if (nodesHasEdge.has(tableName)) {
           // node that has some edges, then show them at second to last
           // row
           foundIdx = countGroups.length;
@@ -126,7 +127,7 @@ export default function RelationshipChartPage() {
 
       const colIdx = i++;
       const rowIdx = foundIdx;
-      node.position.x = width * colIdx + widthDelta * colIdx
+      node.position.x = width * colIdx + widthDelta * colIdx;
       node.position.y = height * rowIdx + heightDelta * rowIdx;
     }
 

--- a/src/frontend/views/RelationshipChartPage/index.tsx
+++ b/src/frontend/views/RelationshipChartPage/index.tsx
@@ -18,6 +18,11 @@ type MyNode = any;
 
 type MyEdge = any;
 
+const width = 200;
+const widthDelta = 10;
+const height = 80;
+const heightDelta = 25;
+
 export default function RelationshipChartPage() {
   const urlParams = useParams();
   const connectionId = urlParams.connectionId as string;
@@ -56,26 +61,19 @@ export default function RelationshipChartPage() {
     const newNodes: MyNode[] = [];
     const newEdges: MyEdge[] = [];
 
-    const width = 200;
-    const widthDelta = 100;
-    const height = 25;
-    const heightDelta = 100;
-
     const mapNodeConnectionsCount: Record<string, number> = {}; // connection => count
+    const nodesHasEdge = new Set<string>();
 
-    let i = 0;
     for (const tableName of Object.keys(data)) {
       newNodes.push({
         id: tableName,
         data: { label: tableName },
         connectable: false,
-        position: { x: width * 3 + widthDelta * 3, y: i * height + i * heightDelta },
+        position: { x: 0, y: 0 },
       });
-
-      i++;
     }
 
-    for (const tableName of Object.keys(data)) {
+    for (const tableName of Object.keys(data).sort()) {
       const tableColumns = data[tableName];
 
       for (const tableColumn of tableColumns) {
@@ -84,7 +82,7 @@ export default function RelationshipChartPage() {
             (edge) => edge.source === tableName && edge.target === tableColumn.referencedTableName,
           );
 
-          newEdges.push({
+          const newEdge = ({
             _label: `${tableColumn.name} => ${tableColumn.referencedTableName}.${tableColumn.referencedColumnName}`,
             id: `${tableName}.${tableColumn.name} => ${tableColumn.referencedTableName}.${tableColumn.referencedColumnName}`,
             source: tableName, // from
@@ -95,6 +93,11 @@ export default function RelationshipChartPage() {
           mapNodeConnectionsCount[tableColumn.referencedTableName] =
             mapNodeConnectionsCount[tableColumn.referencedTableName] || 0;
           mapNodeConnectionsCount[tableColumn.referencedTableName]++;
+
+          nodesHasEdge.add(newEdge.source);
+          nodesHasEdge.add(newEdge.target);
+
+          newEdges.push(newEdge);
         }
       }
     }
@@ -102,28 +105,36 @@ export default function RelationshipChartPage() {
     const countGroups = [...new Set(Object.values(mapNodeConnectionsCount))]
       .map((s) => s as number)
       .sort((a, b) => b - a);
-    const [firstGroup, secondGroup, thirdGroup] = countGroups;
 
+    let i = 0;
     for (const node of newNodes) {
       const tableName = node.id;
       const count = mapNodeConnectionsCount[tableName];
 
-      if (count === firstGroup) {
-        node.position.x = width * 0 + widthDelta * 0;
-        node.sourcePosition = 'right';
-        node.targetPosition = 'right';
-      } else if (count === secondGroup) {
-        node.position.x = width * 1 + widthDelta * 1;
-      } else if (count === thirdGroup) {
-        node.position.x = width * 2 + widthDelta * 2;
+      let foundIdx = countGroups.indexOf(count);
+      if(foundIdx === -1){
+        if(nodesHasEdge.has(tableName)){
+          // node that has some edges, then show them at second to last
+          // row
+          foundIdx = countGroups.length;
+        } else {
+          // these are nodes that doesn't have any dependency
+          // show them at the bottom
+          foundIdx = countGroups.length + 1;
+        }
       }
+
+      const colIdx = i++;
+      const rowIdx = foundIdx;
+      node.position.x = width * colIdx + widthDelta * colIdx
+      node.position.y = height * rowIdx + heightDelta * rowIdx;
     }
 
     setNodes(newNodes);
     setEdges(newEdges);
   }, [JSON.stringify(data)]);
 
-  // show labels
+  // show or hide labels
   useEffect(() => {
     setEdges(
       edges.map((edge) => {
@@ -165,18 +176,18 @@ export default function RelationshipChartPage() {
         <Breadcrumbs
           links={[
             {
-              label: <>{connection?.name}</>,
-            },
-            {
-              label: <>{databaseId}</>,
-            },
-            {
               label: (
                 <>
                   <SsidChartIcon fontSize='inherit' />
                   Visualization
                 </>
               ),
+            },
+            {
+              label: <>{connection?.name}</>,
+            },
+            {
+              label: <>{databaseId}</>,
             },
           ]}
         />


### PR DESCRIPTION
Part of #513

- Optimize the layout for rendering of react-flow in relationship visualization to be stretch horizontally



![image](https://user-images.githubusercontent.com/3792401/185157120-afc7913b-a713-4fd4-ab6b-bb75990d0462.png)
