### PR TITLE
Added navigation and option to visualize on a relevant table in relationship visualization

### DIFF
--- a/src/common/adapters/BaseDataAdapter/scripts.ts
+++ b/src/common/adapters/BaseDataAdapter/scripts.ts
@@ -45,6 +45,10 @@ export default abstract class BaseDataScript implements IDataScript {
     return false;
   }
 
+  supportVisualization() {
+    return false;
+  }
+
   // dialect definitions
   getDialectType(dialect?: SqluiCore.Dialect) {
     // attempt to return the first item in the dialects / schemes

--- a/src/common/adapters/DataScriptFactory.ts
+++ b/src/common/adapters/DataScriptFactory.ts
@@ -105,6 +105,10 @@ export function isDialectSupportEditRecordForm(dialect?: string) {
   return dialect && DIALECTS_SUPPORTING_EDIT_FORM.indexOf(dialect) >= 0;
 }
 
+export function isDialectSupportVisualization(dialect?: string) {
+  return _getImplementation(dialect)?.supportVisualization() || false;
+}
+
 export function getSyntaxModeByDialect(dialect?: string) {
   return _getImplementation(dialect)?.getSyntaxMode() || 'sql';
 }

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -11,6 +11,7 @@ export default interface IDataScript {
   supportMigration: () => boolean;
   supportCreateRecordForm: () => boolean;
   supportEditRecordForm: () => boolean;
+  supportVisualization:() => boolean;
 
   // dialect definitions
   getDialectType: (dialect?: SqluiCore.Dialect) => SqluiCore.Dialect | undefined;

--- a/src/common/adapters/IDataScript.ts
+++ b/src/common/adapters/IDataScript.ts
@@ -11,7 +11,7 @@ export default interface IDataScript {
   supportMigration: () => boolean;
   supportCreateRecordForm: () => boolean;
   supportEditRecordForm: () => boolean;
-  supportVisualization:() => boolean;
+  supportVisualization: () => boolean;
 
   // dialect definitions
   getDialectType: (dialect?: SqluiCore.Dialect) => SqluiCore.Dialect | undefined;

--- a/src/common/adapters/RelationalDataAdapter/scripts.ts
+++ b/src/common/adapters/RelationalDataAdapter/scripts.ts
@@ -655,6 +655,10 @@ export class ConcreteDataScripts extends BaseDataScript {
     return true;
   }
 
+  supportVisualization() {
+    return true;
+  }
+
   // dialect definitions
   getDialectIcon(dialect) {
     switch (dialect) {

--- a/src/common/adapters/_SampleDataAdapter_/scripts.ts
+++ b/src/common/adapters/_SampleDataAdapter_/scripts.ts
@@ -70,6 +70,11 @@ export class ConcreteDataScripts extends BaseDataScript {
   }
 
   // TODO: implement me
+  supportVisualization() {
+    return false;
+  }
+
+  // TODO: implement me
   getConnectionScripts() {
     return [];
   }

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -213,6 +213,15 @@ export default function App() {
                 }
               />
               <Route
+                path='/relationship/:connectionId/:databaseId/:tableId'
+                element={
+                  <>
+                    <AppHeader />
+                    <RelationshipChartPage />
+                  </>
+                }
+              />
+              <Route
                 path='/*'
                 element={
                   <>

--- a/src/frontend/components/ConnectionActions/index.tsx
+++ b/src/frontend/components/ConnectionActions/index.tsx
@@ -13,7 +13,7 @@ import { getConnectionActions } from 'src/common/adapters/DataScriptFactory';
 import DropdownButton from 'src/frontend/components/DropdownButton';
 import { useCommands } from 'src/frontend/components/MissionControl';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
-import { SqluiCore } from 'typings';
+import { SqluiCore, SqlAction } from 'typings';
 
 type ConnectionActionsProps = {
   connection: SqluiCore.ConnectionProps;
@@ -28,7 +28,7 @@ export default function ConnectionActions(props: ConnectionActionsProps): JSX.El
 
   const { dialect, id: connectionId } = connection;
 
-  const options = [
+  const options: SqlAction.Output[] = [
     {
       label: 'Add to Bookmark',
       onClick: () =>

--- a/src/frontend/components/ConnectionActions/index.tsx
+++ b/src/frontend/components/ConnectionActions/index.tsx
@@ -13,7 +13,7 @@ import { getConnectionActions } from 'src/common/adapters/DataScriptFactory';
 import DropdownButton from 'src/frontend/components/DropdownButton';
 import { useCommands } from 'src/frontend/components/MissionControl';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
-import { SqluiCore, SqlAction } from 'typings';
+import { SqlAction, SqluiCore } from 'typings';
 
 type ConnectionActionsProps = {
   connection: SqluiCore.ConnectionProps;

--- a/src/frontend/components/DatabaseActions/index.tsx
+++ b/src/frontend/components/DatabaseActions/index.tsx
@@ -4,7 +4,10 @@ import SsidChartIcon from '@mui/icons-material/SsidChart';
 import IconButton from '@mui/material/IconButton';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
-import { getDatabaseActions } from 'src/common/adapters/DataScriptFactory';
+import {
+  getDatabaseActions,
+  isDialectSupportVisualization,
+} from 'src/common/adapters/DataScriptFactory';
 import DropdownButton from 'src/frontend/components/DropdownButton';
 import { useCommands } from 'src/frontend/components/MissionControl';
 import { useGetConnectionById } from 'src/frontend/hooks/useConnection';
@@ -12,7 +15,6 @@ import { useActiveConnectionQuery } from 'src/frontend/hooks/useConnectionQuery'
 import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import { SqlAction } from 'typings';
-import {isDialectSupportVisualization} from 'src/common/adapters/DataScriptFactory';
 
 type DatabaseActionsProps = {
   connectionId: string;
@@ -40,7 +42,7 @@ export default function DatabaseActions(props: DatabaseActionsProps): JSX.Elemen
 
   const isLoading = loadingConnection;
 
-  let actions : SqlAction.Output[]  = [
+  let actions: SqlAction.Output[] = [
     {
       label: 'Select',
       description: `Selected the related database and connection.`,
@@ -48,7 +50,7 @@ export default function DatabaseActions(props: DatabaseActionsProps): JSX.Elemen
     },
   ];
 
-  if(isDialectSupportVisualization(dialect)){
+  if (isDialectSupportVisualization(dialect)) {
     actions.push({
       label: 'Visualize',
       description: `Visualize all tables in this database.`,

--- a/src/frontend/components/DatabaseActions/index.tsx
+++ b/src/frontend/components/DatabaseActions/index.tsx
@@ -12,6 +12,7 @@ import { useActiveConnectionQuery } from 'src/frontend/hooks/useConnectionQuery'
 import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import { SqlAction } from 'typings';
+import {isDialectSupportVisualization} from 'src/common/adapters/DataScriptFactory';
 
 type DatabaseActionsProps = {
   connectionId: string;
@@ -39,9 +40,7 @@ export default function DatabaseActions(props: DatabaseActionsProps): JSX.Elemen
 
   const isLoading = loadingConnection;
 
-  let actions: SqlAction.Output[] = [];
-
-  actions = [
+  let actions : SqlAction.Output[]  = [
     {
       label: 'Select',
       description: `Selected the related database and connection.`,
@@ -49,23 +48,13 @@ export default function DatabaseActions(props: DatabaseActionsProps): JSX.Elemen
     },
   ];
 
-  // TODO: move this into the interface of script adapter
-  // supportVisualization
-  switch (dialect) {
-    case 'mysql':
-    case 'mariadb':
-    case 'mssql':
-    case 'postgres':
-    case 'postgresql':
-    case 'sqlite':
-      actions.push({
-        label: 'Visualize',
-        description: `Visualize all tables in this database.`,
-        icon: <SsidChartIcon />,
-        //@ts-ignore
-        onClick: () => navigate(`/relationship/${connectionId}/${databaseId}`),
-      });
-      break;
+  if(isDialectSupportVisualization(dialect)){
+    actions.push({
+      label: 'Visualize',
+      description: `Visualize all tables in this database.`,
+      icon: <SsidChartIcon />,
+      onClick: () => navigate(`/relationship/${connectionId}/${databaseId}`),
+    });
   }
 
   actions = [
@@ -82,10 +71,8 @@ export default function DatabaseActions(props: DatabaseActionsProps): JSX.Elemen
     label: action.label,
     startIcon: action.icon,
     onClick: async () =>
-      //@ts-ignore
       action?.onClick
-        ? //@ts-ignore
-          action.onClick()
+        ? action.onClick()
         : selectCommand({
             event: 'clientEvent/query/apply',
             data: {

--- a/src/frontend/components/TableActions/index.tsx
+++ b/src/frontend/components/TableActions/index.tsx
@@ -1,18 +1,20 @@
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import SsidChartIcon from '@mui/icons-material/SsidChart';
 import IconButton from '@mui/material/IconButton';
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
-import { getTableActions } from 'src/common/adapters/DataScriptFactory';
+import { getDivider } from 'src/common/adapters/BaseDataAdapter/scripts';
+import {
+  getTableActions,
+  isDialectSupportVisualization,
+} from 'src/common/adapters/DataScriptFactory';
 import DropdownButton from 'src/frontend/components/DropdownButton';
 import { useCommands } from 'src/frontend/components/MissionControl';
 import { useGetColumns, useGetConnectionById } from 'src/frontend/hooks/useConnection';
 import { useActiveConnectionQuery } from 'src/frontend/hooks/useConnectionQuery';
 import { useQuerySizeSetting } from 'src/frontend/hooks/useSetting';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
-import {isDialectSupportVisualization} from 'src/common/adapters/DataScriptFactory';
-import SsidChartIcon from '@mui/icons-material/SsidChart';
-import { useNavigate } from 'react-router-dom';
 import { SqlAction } from 'typings';
-import BaseDataScript, { getDivider } from 'src/common/adapters/BaseDataAdapter/scripts';
 
 type TableActionsProps = {
   connectionId: string;
@@ -51,29 +53,30 @@ export default function TableActions(props: TableActionsProps): JSX.Element | nu
 
   let actions: SqlAction.Output[] = [];
 
-  if(isDialectSupportVisualization(dialect)){
+  if (isDialectSupportVisualization(dialect)) {
     actions = [
-    ...actions,
-    ({
-          label: 'Visualize',
-          description: `Visualize all tables in this database.`,
-          icon: <SsidChartIcon />,
-          onClick: () => navigate(`/relationship/${connectionId}/${databaseId}/${tableId}`),
-        }),
-    getDivider(),];
+      ...actions,
+      {
+        label: 'Visualize',
+        description: `Visualize all tables in this database.`,
+        icon: <SsidChartIcon />,
+        onClick: () => navigate(`/relationship/${connectionId}/${databaseId}/${tableId}`),
+      },
+      getDivider(),
+    ];
   }
 
   actions = [
-  ...actions,
-  ...getTableActions({
-    dialect,
-    connectionId,
-    databaseId,
-    tableId,
-    columns: columns || [],
-    querySize,
-  })
-  ]
+    ...actions,
+    ...getTableActions({
+      dialect,
+      connectionId,
+      databaseId,
+      tableId,
+      columns: columns || [],
+      querySize,
+    }),
+  ];
 
   const options = actions.map((action) => ({
     label: action.label,
@@ -81,17 +84,17 @@ export default function TableActions(props: TableActionsProps): JSX.Element | nu
     onClick: async () =>
       action?.onClick
         ? action.onClick()
-      : action.query &&
-      selectCommand({
-        event: 'clientEvent/query/apply',
-        data: {
-          connectionId,
-          databaseId,
-          tableId: tableId,
-          sql: action.query,
-        },
-        label: `Applied "${action.label}" to active query tab.`,
-      }),
+        : action.query &&
+          selectCommand({
+            event: 'clientEvent/query/apply',
+            data: {
+              connectionId,
+              databaseId,
+              tableId: tableId,
+              sql: action.query,
+            },
+            label: `Applied "${action.label}" to active query tab.`,
+          }),
   }));
 
   if (!treeActions.showContextMenu) {

--- a/src/frontend/components/TableDescription/index.tsx
+++ b/src/frontend/components/TableDescription/index.tsx
@@ -1,4 +1,3 @@
-import SsidChartIcon from '@mui/icons-material/SsidChart';
 import TableRowsIcon from '@mui/icons-material/TableRows';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';

--- a/src/frontend/components/TableDescription/index.tsx
+++ b/src/frontend/components/TableDescription/index.tsx
@@ -1,3 +1,4 @@
+import SsidChartIcon from '@mui/icons-material/SsidChart';
 import TableRowsIcon from '@mui/icons-material/TableRows';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';

--- a/src/frontend/layout/LayoutTwoColumns.tsx
+++ b/src/frontend/layout/LayoutTwoColumns.tsx
@@ -1,11 +1,11 @@
 import { Bar, Container, Section } from 'react-simple-resizer';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSideBarWidthPreference } from 'src/frontend/hooks/useClientSidePreference';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 
 type LayoutTwoColumnsProps = {
   className?: string;
-  children: ReactElement[];
+  children: JSX.Element[];
 };
 
 export default function LayoutTwoColumns(props: LayoutTwoColumnsProps): JSX.Element | null {

--- a/src/frontend/views/RelationshipChartPage/index.tsx
+++ b/src/frontend/views/RelationshipChartPage/index.tsx
@@ -28,6 +28,7 @@ export default function RelationshipChartPage() {
   const urlParams = useParams();
   const connectionId = urlParams.connectionId as string;
   const databaseId = urlParams.databaseId as string;
+  const tableId = urlParams.tableId as string;
 
   const [nodes, setNodes] = useState<MyNode[]>([]);
   const [edges, setEdges] = useState<MyEdge[]>([]);
@@ -59,8 +60,8 @@ export default function RelationshipChartPage() {
       return;
     }
 
-    const newNodes: MyNode[] = [];
-    const newEdges: MyEdge[] = [];
+    let newNodes: MyNode[] = [];
+    let newEdges: MyEdge[] = [];
 
     const mapNodeConnectionsCount: Record<string, number> = {}; // connection => count
     const nodesHasEdge = new Set<string>();
@@ -101,6 +102,19 @@ export default function RelationshipChartPage() {
           newEdges.push(newEdge);
         }
       }
+    }
+
+    // here we will filter out all the nodes and edges that doesn't have tableId
+    if(tableId){
+      newEdges = newEdges.filter(edge => edge.source === tableId || edge.target === tableId)
+
+      const nodesToKeep = new Set([tableId]);
+      for(const edge of newEdges){
+        nodesToKeep.add(edge.source);
+        nodesToKeep.add(edge.target);
+      }
+
+      newNodes = newNodes.filter(node => nodesToKeep.has(node.id));
     }
 
     const countGroups = [...new Set(Object.values(mapNodeConnectionsCount))]
@@ -171,26 +185,35 @@ export default function RelationshipChartPage() {
     );
   }
 
+  const breadcrumbsData = [
+    {
+      label: (
+        <>
+          <SsidChartIcon fontSize='inherit' />
+          Visualization
+        </>
+      ),
+    },
+    {
+      label: <>{connection?.name}</>,
+    },
+    {
+      label: <>{databaseId}</>,
+    },
+  ];
+
+  if(tableId){
+    breadcrumbsData.push({
+      label:<>{tableId}</>
+    });
+  }
+
+
   return (
     <>
       <Box sx={{ mx: 2, display: 'flex', alignItems: 'center' }}>
         <Breadcrumbs
-          links={[
-            {
-              label: (
-                <>
-                  <SsidChartIcon fontSize='inherit' />
-                  Visualization
-                </>
-              ),
-            },
-            {
-              label: <>{connection?.name}</>,
-            },
-            {
-              label: <>{databaseId}</>,
-            },
-          ]}
+          links={breadcrumbsData}
         />
         <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 2 }}>
           <Button onClick={onToggleShowLabels}>{showLabels ? 'Hide Labels' : 'Show Labels'}</Button>

--- a/src/frontend/views/RelationshipChartPage/index.tsx
+++ b/src/frontend/views/RelationshipChartPage/index.tsx
@@ -21,6 +21,7 @@ type MyEdge = any;
 const width = 200;
 
 const widthDelta = 10;
+
 const height = 80;
 const heightDelta = 25;
 
@@ -105,16 +106,16 @@ export default function RelationshipChartPage() {
     }
 
     // here we will filter out all the nodes and edges that doesn't have tableId
-    if(tableId){
-      newEdges = newEdges.filter(edge => edge.source === tableId || edge.target === tableId)
+    if (tableId) {
+      newEdges = newEdges.filter((edge) => edge.source === tableId || edge.target === tableId);
 
       const nodesToKeep = new Set([tableId]);
-      for(const edge of newEdges){
+      for (const edge of newEdges) {
         nodesToKeep.add(edge.source);
         nodesToKeep.add(edge.target);
       }
 
-      newNodes = newNodes.filter(node => nodesToKeep.has(node.id));
+      newNodes = newNodes.filter((node) => nodesToKeep.has(node.id));
     }
 
     const countGroups = [...new Set(Object.values(mapNodeConnectionsCount))]
@@ -202,19 +203,15 @@ export default function RelationshipChartPage() {
     },
   ];
 
-  if(tableId){
+  if (tableId) {
     breadcrumbsData.push({
-      label:<>{tableId}</>
+      label: <>{tableId}</>,
     });
   }
-
-
   return (
     <>
       <Box sx={{ mx: 2, display: 'flex', alignItems: 'center' }}>
-        <Breadcrumbs
-          links={breadcrumbsData}
-        />
+        <Breadcrumbs links={breadcrumbsData} />
         <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 2 }}>
           <Button onClick={onToggleShowLabels}>{showLabels ? 'Hide Labels' : 'Show Labels'}</Button>
           <Button onClick={onDownload}>Download</Button>

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -246,7 +246,7 @@ export module SqlAction {
      * @type {[type]}
      */
     skipGuide?: boolean;
-    onClick?:() => void;
+    onClick?: () => void;
     startIcon?: JSX.Element;
   };
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -246,6 +246,8 @@ export module SqlAction {
      * @type {[type]}
      */
     skipGuide?: boolean;
+    onClick?:() => void;
+    startIcon?: JSX.Element;
   };
 
   export type TableActionScriptGenerator = (


### PR DESCRIPTION
Part of #513 

- Added navigation and option to visualize on a relevant table in relationship visualization. This is done in a new route `/relationship/:connectionId/:databaseId/:tableId`.
- Consolidated `supportVisualization` into the data script class definition.
- Added `onClick` and `startIcon` into the `SqlAction.Output` typing to clean up more `@ts-ignore`.

![image](https://user-images.githubusercontent.com/3792401/185172292-91bc6517-4366-45be-8c38-c018e2290cbd.png)

![image](https://user-images.githubusercontent.com/3792401/185172460-8a58ef8c-db32-418a-9272-3f37d901b4ef.png)