### PR TITLE
Reset the selection range in the monaco editor after the query is changed

### DIFF
--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
@@ -73,6 +73,8 @@ export default function AdvancedEditor(props: AdvancedEditorProps): JSX.Element 
           },
         ]);
 
+        editor.setSelection(new monaco.Selection(1, 1, 1, 1));
+
         // Indicates the above edit is a complete undo/redo change.
         editor.pushUndoStop();
       } else {


### PR DESCRIPTION
The issue happens to monaco editor when you have some text highlighted in the editor, then go and apply another query, the range is still present. So it makes the execution to execute only the highlighted text.

- The fix is to reset the selection range when there is a change in `props.value`

### Screenshot
- Highlight some text
![image](https://user-images.githubusercontent.com/3792401/191995341-006e3070-b8c2-4b03-b81e-a29c4e8f9c5f.png)


- Notice after I applied another query, it still keeps the old selection range in the editor.
![image](https://user-images.githubusercontent.com/3792401/191995570-2f3b9310-1600-4e4a-b29f-53cdad372df9.png)

- The fix is to reset the selection range in the code editor after the query is applied
![image](https://user-images.githubusercontent.com/3792401/191995431-4a2a192b-ee45-4fee-991e-f18145453a29.png)


### API note
- https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ICodeEditor.html
- `editor.setSelection(new monaco.Selection(1, 1, 1, 1));` to reset the selection range