### PR TITLE
Persist code editor undo stack across interactions

### DIFF
--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -17,6 +17,7 @@ export type EditorRef =
   | undefined;
 
 export type CodeEditorProps = {
+  id?: string;
   language?: 'sql' | string;
   value?: string;
   autoFocus?: boolean;
@@ -102,6 +103,7 @@ export default function CodeEditorBox(props: CodeEditorProps): JSX.Element | nul
     return (
       <div className='CodeEditorBox'>
         <SimpleEditor
+          id={props.id}
           value={props.value}
           placeholder={props.placeholder}
           onBlur={onChange}
@@ -121,6 +123,7 @@ export default function CodeEditorBox(props: CodeEditorProps): JSX.Element | nul
     <Box>
       <Paper className='CodeEditorBox' variant='outlined'>
         <AdvancedEditor
+          id={props.id}
           language={languageToUse}
           value={props.value}
           onBlur={onChange}

--- a/src/frontend/components/QueryBox/index.tsx
+++ b/src/frontend/components/QueryBox/index.tsx
@@ -288,6 +288,7 @@ export default function QueryBox(props: QueryBoxProps): JSX.Element | null {
           <ConnectionActionsButton query={query} />
         </div>
         <CodeEditorBox
+          id={query.id}
           value={query.sql}
           placeholder={`Enter SQL for ` + query.name}
           onChange={onSqlQueryChange}


### PR DESCRIPTION
### Problem:
Code editor undo stacks do not persist when you switch tabs

### Solution
- Tied each editor instance to an `id` and store the undo stacks in a map and restore it accordingly.

### TODOs:
- Need to clean up the undo stack when the query is deleted. Need to create a hook to access the content of the todo stacks.