### PR TITLE
Disable smooth scrolling for mac

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -8,6 +8,12 @@ import { SqluiCore, SqluiEnums } from 'typings';
 
 const isMac = process.platform === 'darwin';
 
+// disable smooth scrolling
+try{
+  app.commandLine.appendSwitch('--disable-smooth-scrolling');
+} catch(err){}
+
+
 async function createWindow(isFirstWindow?: boolean) {
   const mainWindow = new BrowserWindow({
     width: 1200,
@@ -306,7 +312,6 @@ app.on('window-all-closed', () => {
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
 // events
-
 ipcMain.handle('dark-mode:toggle', () => {
   if (nativeTheme.shouldUseDarkColors) {
     nativeTheme.themeSource = 'light';

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -9,11 +9,9 @@ import { SqluiCore, SqluiEnums } from 'typings';
 const isMac = process.platform === 'darwin';
 
 // disable smooth scrolling
-try{
+try {
   app.commandLine.appendSwitch('--disable-smooth-scrolling');
-} catch(err){}
-
-
+} catch (err) {}
 async function createWindow(isFirstWindow?: boolean) {
   const mainWindow = new BrowserWindow({
     width: 1200,

--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
@@ -21,7 +21,7 @@ const DEFAULT_OPTIONS = {
   },
 };
 
-const EDITOR_MODELS_MAP : Record<string, any> = {};
+const EDITOR_MODELS_MAP: Record<string, any> = {};
 
 export default function AdvancedEditor(props: AdvancedEditorProps): JSX.Element | null {
   const colorMode = useDarkModeSetting();
@@ -45,7 +45,7 @@ export default function AdvancedEditor(props: AdvancedEditorProps): JSX.Element 
       });
 
       // clean up the model as we don't need it while it's active
-      if(props.id && EDITOR_MODELS_MAP[props.id]){
+      if (props.id && EDITOR_MODELS_MAP[props.id]) {
         newEditor.setModel(EDITOR_MODELS_MAP[props.id]);
         delete EDITOR_MODELS_MAP[props.id];
       }
@@ -62,20 +62,16 @@ export default function AdvancedEditor(props: AdvancedEditorProps): JSX.Element 
       setEditor(null);
     };
   }, []);
-
-
   // this is used to clean up the editor
   useEffect(() => {
     return () => {
       // keep track of the undo if we need it
-      if(editor && props.id){
+      if (editor && props.id) {
         // https://stackoverflow.com/questions/48210120/get-restore-monaco-editor-undoredo-stack
         EDITOR_MODELS_MAP[props.id] = editor?.getModel();
       }
     };
   }, [editor, props.id]);
-
-
   // we used this block to set the value of the editor
   useEffect(() => {
     if (editor) {


### PR DESCRIPTION
- Chrome 91+ on Mac enable smooth scrolling by default, this behavior is slow for external mouse. There's a delay when the transition happens with external mouse.
- This will greatly improve the performance.

More info here https://github.com/electron/electron/issues/5460