### PR TITLE
Fixed conflicts with shortcut keyboard (`Ctrl +F` and `Ctrl + Enter`)

### DIFF
--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -19,6 +19,7 @@ export type EditorRef =
 export type CodeEditorProps = {
   id?: string;
   language?: 'sql' | string;
+  className?: string;
   value?: string;
   autoFocus?: boolean;
   onChange?: (newValue: string) => void;
@@ -101,7 +102,7 @@ export default function CodeEditorBox(props: CodeEditorProps): JSX.Element | nul
 
   if (editorModeToUse === 'simple') {
     return (
-      <div className='CodeEditorBox'>
+      <div className={'CodeEditorBox ' + props.className}>
         <SimpleEditor
           id={props.id}
           value={props.value}
@@ -121,7 +122,7 @@ export default function CodeEditorBox(props: CodeEditorProps): JSX.Element | nul
 
   return (
     <Box>
-      <Paper className='CodeEditorBox' variant='outlined'>
+      <Paper className={'CodeEditorBox ' + props.className} variant='outlined'>
         <AdvancedEditor
           id={props.id}
           language={languageToUse}

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1442,9 +1442,18 @@ export default function MissionControl() {
 
           case 'f':
             try {
-              (document.querySelector('#result-box-search-input') as HTMLInputElement)?.focus();
-              e.stopPropagation();
-              e.preventDefault();
+              // making sure we don't interfere Ctrl+f with other input
+              const activeInputTagName = document.activeElement?.tagName.toLowerCase();
+              if(activeInputTagName === 'textarea' || activeInputTagName === 'input'){
+                return;
+              }
+
+              const resultSearchBox = document.querySelector('#result-box-search-input') as HTMLInputElement;
+              if(resultSearchBox){
+                resultSearchBox.focus();
+                e.stopPropagation();
+                e.preventDefault();
+              }
             } catch (err) {}
             break;
         }

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1432,8 +1432,8 @@ export default function MissionControl() {
             // traverse up until we find the code editor wrapper or reach the root html element
             let currentDomNode = activeElement;
             let shouldExecuteQuery = false;
-            while(currentDomNode){
-              if(currentDomNode.classList.contains('CodeEditorBox__QueryBox')){
+            while (currentDomNode) {
+              if (currentDomNode.classList.contains('CodeEditorBox__QueryBox')) {
                 shouldExecuteQuery = true;
                 break;
               }
@@ -1441,7 +1441,7 @@ export default function MissionControl() {
             }
 
             try {
-              if(shouldExecuteQuery){
+              if (shouldExecuteQuery) {
                 (
                   document.querySelector(
                     '.AdvancedEditorContainer .inputarea.monaco-mouse-cursor-text,.SimpleEditorContainer',
@@ -1460,12 +1460,14 @@ export default function MissionControl() {
           case 'f':
             try {
               // making sure we don't interfere Ctrl+f with other input
-              if(activeInputTagName === 'textarea' || activeInputTagName === 'input'){
+              if (activeInputTagName === 'textarea' || activeInputTagName === 'input') {
                 return;
               }
 
-              const resultSearchBox = document.querySelector('#result-box-search-input') as HTMLInputElement;
-              if(resultSearchBox){
+              const resultSearchBox = document.querySelector(
+                '#result-box-search-input',
+              ) as HTMLInputElement;
+              if (resultSearchBox) {
                 resultSearchBox.focus();
                 e.stopPropagation();
                 e.preventDefault();

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1422,28 +1422,44 @@ export default function MissionControl() {
 
       // here are keybindings that are used for both the electron and web mocked
       if (hasModifierKey) {
+        const activeElement = document.activeElement;
+        const activeInputTagName = activeElement?.tagName.toLowerCase();
+
         // with modifier key
         switch (key) {
           case 'Enter':
-            try {
-              (
-                document.querySelector(
-                  '.AdvancedEditorContainer .inputarea.monaco-mouse-cursor-text,.SimpleEditorContainer',
-                ) as HTMLTextAreaElement
-              ).blur();
+            // Ctrl+Enter to execute the query
+            // traverse up until we find the code editor wrapper or reach the root html element
+            let currentDomNode = activeElement;
+            let shouldExecuteQuery = false;
+            while(currentDomNode){
+              if(currentDomNode.classList.contains('CodeEditorBox__QueryBox')){
+                shouldExecuteQuery = true;
+                break;
+              }
+              currentDomNode = currentDomNode.parentElement;
+            }
 
-              setTimeout(() =>
-                (document.querySelector('#btnExecuteCommand') as HTMLButtonElement).click(),
-              );
-              e.stopPropagation();
-              e.preventDefault();
+            try {
+              if(shouldExecuteQuery){
+                (
+                  document.querySelector(
+                    '.AdvancedEditorContainer .inputarea.monaco-mouse-cursor-text,.SimpleEditorContainer',
+                  ) as HTMLTextAreaElement
+                ).blur();
+
+                setTimeout(() =>
+                  (document.querySelector('#btnExecuteCommand') as HTMLButtonElement).click(),
+                );
+                e.stopPropagation();
+                e.preventDefault();
+              }
             } catch (err) {}
             break;
 
           case 'f':
             try {
               // making sure we don't interfere Ctrl+f with other input
-              const activeInputTagName = document.activeElement?.tagName.toLowerCase();
               if(activeInputTagName === 'textarea' || activeInputTagName === 'input'){
                 return;
               }

--- a/src/frontend/components/QueryBox/index.tsx
+++ b/src/frontend/components/QueryBox/index.tsx
@@ -289,6 +289,7 @@ export default function QueryBox(props: QueryBoxProps): JSX.Element | null {
         </div>
         <CodeEditorBox
           id={query.id}
+          className='CodeEditorBox__QueryBox'
           value={query.sql}
           placeholder={`Enter SQL for ` + query.name}
           onChange={onSqlQueryChange}


### PR DESCRIPTION
- Fixed conflicts with shortcut keyboard (`Ctrl+F` and `Ctrl+Enter`).

### Why?
- `Ctrl+F` is interfering with the search box in the results search box. So when you are focused on the code editor, it should prompt the code search instead.
- `Ctrl+Enter` runs unbounded regardless if the focus is on the code editor. This will make sure the focus must be inside of the code editor.