### PR TITLE
Consolidate into reusable workflows

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,5 +1,3 @@
-name: build-main
-
 on:
   push:
     branches: [master, main]

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,5 +1,3 @@
-name: build-pr
-
 on:
   pull_request:
     branches: [master, main]
@@ -10,22 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-          cache: 'yarn'
-      - run: yarn install --network-timeout 1000000 --frozen-lockfile
-      - run: yarn check
-      - run: yarn format
-      - run: yarn test-ci
-      - run: yarn build
-      - uses: EndBug/add-and-commit@v8
-        with:
-          message: 'CI / CD - Format Updates Automatic Commit'
-        continue-on-error: true
+    # https://github.com/synle/gha-workflows/blob/main/.github/workflows/pr-js-yarn.yml
+    uses: synle/gha-workflows/.github/workflows/pr-js-yarn.yml@main
+    with:
+      os: ubuntu-latest

--- a/.github/workflows/dist-main.yml
+++ b/.github/workflows/dist-main.yml
@@ -1,5 +1,3 @@
-name: dist-main
-
 on:
   workflow_dispatch:
     inputs:

--- a/installation.md
+++ b/installation.md
@@ -61,7 +61,6 @@ sudo dpkg -i sqlui-native*.deb
 sudo rpm -i sqlui-native*.rpm
 ```
 
-
 ## Arch Linux with pacman
 
 ```


### PR DESCRIPTION
- Consolidate into reusable workflows
- Removed the optional `name` property in the action yml 


### Reusable build for build-pr
https://github.com/synle/gha-workflows/blob/main/.github/workflows/pr-js-yarn.yml