### PR TITLE
Sort order of the column headers always sorted alphabetically

### DIFF
--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -60,7 +60,7 @@ export function DataTableWithJSONList(props: Omit<DataTableProps, 'columns'>) {
       }
     }
 
-    return sortColumnNamesForUnknownData([...newColumnNames]).map((columnName) => {
+    return [...newColumnNames].map((columnName) => {
       return {
         Header: columnName,
         sortable: true,

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import LegacyDataTable from 'src/frontend/components/DataTable/LegacyDataTable';
 import ModernDataTable from 'src/frontend/components/DataTable/ModernDataTable';
 import { DropdownButtonOption } from 'src/frontend/components/DropdownButton';
-import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
 
 export type DataTableProps = {
   columns: any[];

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -49,7 +49,6 @@ import {
 import useToaster from 'src/frontend/hooks/useToaster';
 import { useTreeActions } from 'src/frontend/hooks/useTreeActions';
 import LayoutTwoColumns from 'src/frontend/layout/LayoutTwoColumns';
-import { sortColumnNamesForUnknownData } from 'src/frontend/utils/commonUtils';
 import { formatJS, formatSQL } from 'src/frontend/utils/formatter';
 import { SqluiCore, SqluiFrontend } from 'typings';
 

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -79,7 +79,7 @@ type RecordFormReponse = {
  */
 function RecordView(props: RecordDetailsPageProps): JSX.Element | null {
   const { data } = props;
-  const columnNames = sortColumnNamesForUnknownData(Object.keys(data || {}));
+  const columnNames = Object.keys(data || {});
 
   return (
     <>


### PR DESCRIPTION
Fixes #698

Sort order of the column headers always sorted alphabetically

- We should use the actual sort order from the query for the column headers instead of always sorting it alphabetically
