### PR TITLE
Improve scrolling on mac (disable smooth scrolling)

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -10,8 +10,10 @@ const isMac = process.platform === 'darwin';
 
 // disable smooth scrolling
 try {
-  app.commandLine.appendSwitch('--disable-smooth-scrolling');
+  app.commandLine.appendSwitch('disable-smooth-scrolling');
 } catch (err) {}
+
+// create the window
 async function createWindow(isFirstWindow?: boolean) {
   const mainWindow = new BrowserWindow({
     width: 1200,


### PR DESCRIPTION
Fixes #704 

Mac Smooth Scrolling feels unresponsive. Disable smooth scrolling seems to help

`app.commandLine.appendSwitch('disable-smooth-scrolling`
- https://github.com/electron/electron/issues/11583
- https://github.com/electron/electron/issues/28537#issuecomment-815072372
- https://github.com/revoltchat/desktop/issues/94