### PR TITLE
Feature: Query Tab Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ Dark mode will be turned on automatically with respect to your OS Preference. Yo
 
 ### Query Tabs
 
+#### Query Tab Persistence
+
+Open query tabs can be restored across app restarts with their query text, tab order, selected tab, and pinned state. In Settings, use `Query Tab Persistence` to choose automatic saving or manual saving via the query tab dropdown's `Save` / `Save All Tabs` actions.
+
 #### Query Tab Orientation
 
 When there are more than 20 tabs, the query tabs wrap vertically.

--- a/src/common/Endpoints.ts
+++ b/src/common/Endpoints.ts
@@ -38,6 +38,7 @@ const DEFAULT_SETTINGS = {
   animationMode: "on",
   layoutMode: "compact",
   querySelectionMode: "new-tab",
+  queryTabPersistenceMode: "auto",
   editorMode: "advanced",
   tableRenderer: "advanced",
   wordWrap: "wrap",

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -379,6 +379,41 @@ export default function MissionControl() {
     downloadText(`${query.name}.query.json`, JSON.stringify([getExportedQuery(query)], null, 2), "text/json");
   };
 
+  /**
+   * Saves one query tab and reports success or failure with a toast.
+   * @param query - Query tab to persist.
+   */
+  const onSaveQuery = async (query: SqluiFrontend.ConnectionQuery) => {
+    try {
+      await connectionQueries.onSaveQuery(query.id);
+      await addToast({
+        message: `Query "${query.name}" saved.`,
+      });
+    } catch (err) {
+      console.error("index.tsx:onSaveQuery", err);
+      await addToast({
+        message: `Failed to save query "${query.name}".`,
+      });
+    }
+  };
+
+  /**
+   * Saves all open query tabs and reports success or failure with a toast.
+   */
+  const onSaveAllQueries = async () => {
+    try {
+      const savedCount = await connectionQueries.onSaveQueries();
+      await addToast({
+        message: `${savedCount} query tab${savedCount === 1 ? "" : "s"} saved.`,
+      });
+    } catch (err) {
+      console.error("index.tsx:onSaveAllQueries", err);
+      await addToast({
+        message: `Failed to save query tabs.`,
+      });
+    }
+  };
+
   const onAddQueryToBookmark = async (query: SqluiFrontend.ConnectionQuery) => {
     const { selected, ...restOfQuery } = query;
 
@@ -1520,6 +1555,18 @@ export default function MissionControl() {
           if (command.data) {
             onExportQuery(command.data as SqluiFrontend.ConnectionQuery);
           }
+          break;
+
+        case "clientEvent/query/save":
+          if (command.data) {
+            onSaveQuery(command.data as SqluiFrontend.ConnectionQuery);
+          } else if (activeQuery) {
+            onSaveQuery(activeQuery as SqluiFrontend.ConnectionQuery);
+          }
+          break;
+
+        case "clientEvent/query/saveAll":
+          onSaveAllQueries();
           break;
 
         case "clientEvent/query/duplicate":

--- a/src/frontend/components/QueryBoxTabs/index.tsx
+++ b/src/frontend/components/QueryBoxTabs/index.tsx
@@ -6,18 +6,19 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import EditIcon from "@mui/icons-material/Edit";
 import PushPinIcon from "@mui/icons-material/PushPin";
 import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
+import SaveIcon from "@mui/icons-material/Save";
 import StarIcon from "@mui/icons-material/Star";
 import Alert from "@mui/material/Alert";
 import CircularProgress from "@mui/material/CircularProgress";
 import Link from "@mui/material/Link";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import DropdownButton from "src/frontend/components/DropdownButton";
 import { allMenuKeys, useCommands } from "src/frontend/components/MissionControl";
 import { platform } from "src/frontend/platform";
 import QueryBox from "src/frontend/components/QueryBox";
 import Tabs from "src/frontend/components/Tabs";
 import { useConnectionQueries } from "src/frontend/hooks/useConnectionQuery";
-import { useQueryTabOrientationSetting } from "src/frontend/hooks/useSetting";
+import { useIsQueryTabAutoSaveEnabled, useQueryTabOrientationSetting } from "src/frontend/hooks/useSetting";
 import { SqluiFrontend } from "typings";
 
 /**
@@ -27,9 +28,11 @@ import { SqluiFrontend } from "typings";
  */
 export default function QueryBoxTabs() {
   const [init, setInit] = useState(false);
-  const { queries, isLoading } = useConnectionQueries();
+  const { queries, isLoading, onSaveQueries } = useConnectionQueries();
   const { selectCommand } = useCommands();
   const queryTabOrientation = useQueryTabOrientationSetting();
+  const isQueryTabAutoSaveEnabled = useIsQueryTabAutoSaveEnabled();
+  const previousAutoSaveEnabledRef = useRef(isQueryTabAutoSaveEnabled);
 
   const onShowQuery = useCallback(
     (data: SqluiFrontend.ConnectionQuery) => selectCommand({ event: "clientEvent/query/show", data }),
@@ -68,6 +71,13 @@ export default function QueryBoxTabs() {
     [selectCommand],
   );
 
+  const onSaveQuery = useCallback(
+    (data: SqluiFrontend.ConnectionQuery) => selectCommand({ event: "clientEvent/query/save", data }),
+    [selectCommand],
+  );
+
+  const onSaveAllQueries = useCallback(() => selectCommand({ event: "clientEvent/query/saveAll" }), [selectCommand]);
+
   const onAddToBookmark = useCallback(
     (data: SqluiFrontend.ConnectionQuery) => selectCommand({ event: "clientEvent/query/addToBookmark", data }),
     [selectCommand],
@@ -94,6 +104,16 @@ export default function QueryBoxTabs() {
     }
   }, [isLoading, queries, init]);
 
+  // When a user flips Manual Save Only back to Auto-save, register any manual-mode client-generated tabs immediately.
+  useEffect(() => {
+    const wasAutoSaveEnabled = previousAutoSaveEnabledRef.current;
+    previousAutoSaveEnabledRef.current = isQueryTabAutoSaveEnabled;
+
+    if (!wasAutoSaveEnabled && isQueryTabAutoSaveEnabled && !isLoading && queries && queries.length > 0) {
+      onSaveQueries().catch((err) => console.error("QueryBoxTabs:onSaveQueries", err));
+    }
+  }, [isQueryTabAutoSaveEnabled, isLoading, queries, onSaveQueries]);
+
   // this section is specific to electron
   // we only want to show the query menu for
   // electron only when we can see the query tabs...
@@ -112,6 +132,17 @@ export default function QueryBoxTabs() {
     () => [
       ...(queries || []).map((q, idx) => {
         let options = [
+          {
+            label: "Save",
+            onClick: () => onSaveQuery(q),
+            startIcon: <SaveIcon />,
+          },
+          {
+            label: "Save All Tabs",
+            onClick: () => onSaveAllQueries(),
+            startIcon: <SaveIcon />,
+          },
+          { label: "divider" },
           {
             label: "Add to Bookmark",
             onClick: () => onAddToBookmark(q),

--- a/src/frontend/components/Settings/index.spec.tsx
+++ b/src/frontend/components/Settings/index.spec.tsx
@@ -18,6 +18,7 @@ vi.mock("src/frontend/hooks/useSetting", () => ({
       deleteMode: "soft-delete",
       animationMode: "",
       querySelectionMode: "new-tab",
+      queryTabPersistenceMode: "auto",
     },
     onChange: vi.fn(),
   }),
@@ -52,6 +53,11 @@ describe("Settings", () => {
   test("renders Query Size label", () => {
     const { container } = renderWithTheme(<Settings />);
     expect(container.textContent).toContain("Query Size");
+  });
+
+  test("renders Query Tab Persistence label", () => {
+    const { container } = renderWithTheme(<Settings />);
+    expect(container.textContent).toContain("Query Tab Persistence");
   });
 
   test("renders Delete Mode label", () => {

--- a/src/frontend/components/Settings/index.tsx
+++ b/src/frontend/components/Settings/index.tsx
@@ -108,6 +108,22 @@ export default function Settings(): React.JSX.Element | null {
           </Select>
         </div>
         <Typography className="FormInput__Label" variant="subtitle1">
+          Query Tab Persistence
+          <Tooltip title="Auto-save restores all open query tabs after reopening the app. Manual saves only when using the tab save actions.">
+            <HelpIcon fontSize="small" sx={{ ml: 1 }} />
+          </Tooltip>
+        </Typography>
+        <div className="FormInput__Row">
+          <Select
+            value={settings.queryTabPersistenceMode || "auto"}
+            onChange={(newValue) => onSettingChange("queryTabPersistenceMode", newValue)}
+            sx={{ width: "100%" }}
+          >
+            <option value="auto">Auto-save Open Tabs</option>
+            <option value="manual">Manual Save Only</option>
+          </Select>
+        </div>
+        <Typography className="FormInput__Label" variant="subtitle1">
           Editor Mode
           <Tooltip title="Which editor to use? Simple Editor vs Advanced Editor">
             <HelpIcon fontSize="small" sx={{ ml: 1 }} />

--- a/src/frontend/hooks/useConnectionQuery.spec.tsx
+++ b/src/frontend/hooks/useConnectionQuery.spec.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { SqluiFrontend } from "typings";
+
+const mockSettings = vi.hoisted(() => ({
+  isQueryTabAutoSaveEnabled: true,
+}));
 
 vi.mock("src/frontend/data/api", () => ({
   default: {
@@ -23,15 +28,38 @@ vi.mock("src/frontend/hooks/useFolderItems", () => ({
 }));
 
 vi.mock("src/frontend/hooks/useSetting", () => ({
+  useIsQueryTabAutoSaveEnabled: () => mockSettings.isQueryTabAutoSaveEnabled,
   useIsSoftDeleteModeSetting: () => false,
 }));
 
 vi.mock("src/frontend/utils/commonUtils", () => ({
   getGeneratedRandomId: (prefix: string) => `${prefix}_test123`,
-  getUpdatedOrdersForList: (list: any[], _from: number, _to: number) => list,
+  getUpdatedOrdersForList: (items: any[], from: number, to: number) => {
+    if (from === to) {
+      return items;
+    }
+
+    const targetItem = items[from];
+    const toBeDeletedListItem = Symbol("to_be_deleted_list_item");
+    items[from] = toBeDeletedListItem;
+    items.splice(from > to ? to : to + 1, 0, targetItem);
+
+    return items.filter((item) => item !== toBeDeletedListItem);
+  },
 }));
 
 import WrappedContext, { useConnectionQueries } from "src/frontend/hooks/useConnectionQuery";
+import dataApi from "src/frontend/data/api";
+import { SessionStorageConfig } from "src/frontend/data/config";
+
+function makeQuery(id: string, overrides: Partial<SqluiFrontend.ConnectionQuery> = {}): SqluiFrontend.ConnectionQuery {
+  return {
+    id,
+    name: id,
+    sql: `select '${id}'`,
+    ...overrides,
+  };
+}
 
 function Consumer() {
   const { queries, isLoading } = useConnectionQueries();
@@ -39,11 +67,34 @@ function Consumer() {
     <div>
       <span data-testid="loading">{isLoading ? "loading" : "ready"}</span>
       <span data-testid="count">{queries?.length ?? 0}</span>
+      <span data-testid="selected">{queries?.find((query) => query.selected)?.id ?? ""}</span>
     </div>
   );
 }
 
+function ReorderConsumer(props: { from: number; to: number }) {
+  const didReorderRef = useRef(false);
+  const { queries, isLoading, onChangeTabOrdering } = useConnectionQueries();
+
+  useEffect(() => {
+    if (isLoading || didReorderRef.current) {
+      return;
+    }
+
+    didReorderRef.current = true;
+    onChangeTabOrdering(props.from, props.to);
+  }, [isLoading, onChangeTabOrdering, props.from, props.to]);
+
+  return <span data-testid="order">{queries.map((query) => query.id).join(",")}</span>;
+}
+
 describe("useConnectionQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettings.isQueryTabAutoSaveEnabled = true;
+    vi.mocked(SessionStorageConfig.get).mockReturnValue([]);
+  });
+
   test("WrappedContext renders children", () => {
     const { container } = render(
       <WrappedContext>
@@ -60,5 +111,65 @@ describe("useConnectionQuery", () => {
       </WrappedContext>,
     );
     expect(container.querySelector("[data-testid='count']")?.textContent).toContain("0");
+  });
+
+  test("restores the newest selected query tab", async () => {
+    vi.mocked(SessionStorageConfig.get).mockReturnValue([
+      makeQuery("q1", { selected: true, updatedAt: 0 }),
+      makeQuery("q2", { selected: false, updatedAt: 10 }),
+      makeQuery("q3", { selected: true, updatedAt: 20 }),
+    ]);
+
+    const { container } = render(
+      <WrappedContext>
+        <Consumer />
+      </WrappedContext>,
+    );
+
+    await waitFor(() => expect(container.querySelector("[data-testid='selected']")?.textContent).toContain("q3"));
+  });
+
+  test("auto-saves only reordered query tabs when tab ordering changes", async () => {
+    vi.mocked(SessionStorageConfig.get).mockReturnValue([
+      makeQuery("q1", { selected: true }),
+      makeQuery("q2"),
+      makeQuery("q3"),
+      makeQuery("q4"),
+    ]);
+
+    const { container } = render(
+      <WrappedContext>
+        <ReorderConsumer from={0} to={2} />
+      </WrappedContext>,
+    );
+
+    await waitFor(() => expect(container.querySelector("[data-testid='order']")?.textContent).toContain("q2,q3,q1,q4"));
+    await waitFor(() => expect(dataApi.upsertQuery).toHaveBeenCalledTimes(3));
+
+    expect(vi.mocked(dataApi.upsertQuery).mock.calls.map(([query]) => [query.id, query.tabOrder])).toEqual([
+      ["q2", 0],
+      ["q3", 1],
+      ["q1", 2],
+    ]);
+  });
+
+  test("does not auto-save reordered query tabs when manual persistence is enabled", async () => {
+    mockSettings.isQueryTabAutoSaveEnabled = false;
+    vi.mocked(SessionStorageConfig.get).mockReturnValue([
+      makeQuery("q1", { selected: true }),
+      makeQuery("q2"),
+      makeQuery("q3"),
+      makeQuery("q4"),
+    ]);
+
+    const { container } = render(
+      <WrappedContext>
+        <ReorderConsumer from={0} to={2} />
+      </WrappedContext>,
+    );
+
+    await waitFor(() => expect(container.querySelector("[data-testid='order']")?.textContent).toContain("q2,q3,q1,q4"));
+
+    expect(dataApi.upsertQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/hooks/useConnectionQuery.tsx
+++ b/src/frontend/hooks/useConnectionQuery.tsx
@@ -3,8 +3,8 @@ import dataApi from "src/frontend/data/api";
 import { SessionStorageConfig } from "src/frontend/data/config";
 import { getCurrentSessionId } from "src/frontend/data/session";
 import { useAddRecycleBinItem } from "src/frontend/hooks/useFolderItems";
-import { useIsSoftDeleteModeSetting } from "src/frontend/hooks/useSetting";
-import { formatShortDate, getUpdatedOrdersForList } from "src/frontend/utils/commonUtils";
+import { useIsQueryTabAutoSaveEnabled, useIsSoftDeleteModeSetting } from "src/frontend/hooks/useSetting";
+import { formatShortDate, getGeneratedRandomId, getUpdatedOrdersForList } from "src/frontend/utils/commonUtils";
 import { SqluiCore, SqluiFrontend } from "typings";
 
 // connection queries
@@ -15,13 +15,81 @@ const TargetContext = createContext({
   isLoading: true,
 });
 
+/**
+ * Returns query tabs in the shape that is safe to save and restore.
+ * Strips volatile runtime-only fields (`result`, `executionEnd`, `executionStart`, `executing`, `executionDetails`, and `isSnapshot`)
+ * so executions, timers, and snapshot markers do not leak into persisted workspace state.
+ * @param queries - Query tabs to convert; defaults to the current in-memory tab list.
+ * @returns Query tabs with stable tab order and selected state included.
+ */
+function _getPersistableQueries(queries: SqluiFrontend.ConnectionQuery[] = _connectionQueries) {
+  return queries.map((query, idx) => {
+    const { result, executionEnd, executionStart, executing, executionDetails, isSnapshot, ...restOfQuery } = query;
+    return {
+      ...restOfQuery,
+      tabOrder: idx,
+      selected: !!query.selected,
+    };
+  });
+}
+
+/**
+ * Persists the current in-memory query tabs to sessionStorage for same-window reload recovery.
+ */
 function _persistQueries() {
   // store to client
-  const toPersistQueries = _connectionQueries.map((query) => {
-    const { pinned, result, executionEnd, executionStart, executing, executionDetails, ...restOfQuery } = query;
-    return restOfQuery;
-  });
+  const toPersistQueries = _getPersistableQueries();
   SessionStorageConfig.set("clientConfig/cache.connectionQueries", toPersistQueries);
+}
+
+/**
+ * Normalizes restored query tabs by backfilling missing `tabOrder` from array index and sorting by `tabOrder`.
+ * This keeps legacy saved queries usable while restoring tabs in the order the user last saved.
+ * @param queries - Query tabs loaded from sessionStorage or the backend.
+ * @returns Query tabs sorted by persisted tab order.
+ */
+function _normalizeQueries(queries: SqluiFrontend.ConnectionQuery[]) {
+  const normalizedQueries = (queries || []).map((query, idx) => ({
+    ...query,
+    tabOrder: query.tabOrder ?? idx,
+  }));
+
+  return normalizedQueries.sort((a, b) => (a.tabOrder ?? 0) - (b.tabOrder ?? 0));
+}
+
+/**
+ * Finds the tab that should be selected after restore.
+ * If storage contains multiple selected tabs from older single-tab saves, the most recently updated selected tab wins.
+ * @param queries - Normalized query tabs.
+ * @returns The selected query index, or `0` when none are marked selected.
+ */
+function _getRestoredSelectedQueryIndex(queries: SqluiFrontend.ConnectionQuery[]) {
+  let selectedIdx = -1;
+  let selectedUpdatedAt = -1;
+
+  queries.forEach((query, idx) => {
+    if (!query.selected) {
+      return;
+    }
+
+    const updatedAt = query.updatedAt ?? 0;
+    if (selectedIdx === -1 || updatedAt >= selectedUpdatedAt) {
+      selectedIdx = idx;
+      selectedUpdatedAt = updatedAt;
+    }
+  });
+
+  return selectedIdx >= 0 ? selectedIdx : 0;
+}
+
+/**
+ * Finds query IDs whose tab position changed after a reorder.
+ * @param previousQueryIds - Query IDs in their order before the move.
+ * @param currentQueries - Query tabs in their order after the move.
+ * @returns Query IDs that need their persisted tab order refreshed.
+ */
+function _getQueryIdsWithChangedTabOrder(previousQueryIds: string[], currentQueries: SqluiFrontend.ConnectionQuery[]) {
+  return currentQueries.filter((query, idx) => previousQueryIds[idx] !== query.id).map((query) => query.id);
 }
 
 /**
@@ -39,26 +107,21 @@ export default function WrappedContext(props: { children: React.ReactNode }): Re
       try {
         // this is the first time
         // try pulling it in from sessionStorage
-        _connectionQueries = SessionStorageConfig.get<SqluiFrontend.ConnectionQuery[]>("clientConfig/cache.connectionQueries", []);
+        _connectionQueries = _normalizeQueries(
+          SessionStorageConfig.get<SqluiFrontend.ConnectionQuery[]>("clientConfig/cache.connectionQueries", []),
+        );
 
         if (_connectionQueries.length === 0 && getCurrentSessionId()) {
           // if config failed, attempt to get it from the api (only if a session is selected)
           try {
-            _connectionQueries = await dataApi.getQueries();
+            _connectionQueries = _normalizeQueries(await dataApi.getQueries());
           } catch (err) {
             console.error("useConnectionQuery.tsx:getQueries", err);
           }
         }
 
-        // at the end we want to remove executionStart so the query won't be run again
-        let toBeSelectedQuery = 0;
-        _connectionQueries = _connectionQueries.map((query, idx) => {
-          if (query.selected) {
-            toBeSelectedQuery = idx;
-          }
-
-          return { ...query, selected: false };
-        });
+        const toBeSelectedQuery = _getRestoredSelectedQueryIndex(_connectionQueries);
+        _connectionQueries = _connectionQueries.map((query) => ({ ...query, selected: false }));
 
         if (_connectionQueries[toBeSelectedQuery]) {
           _connectionQueries[toBeSelectedQuery] = {
@@ -103,17 +166,52 @@ export function useConnectionQueries() {
   const { data: queries, setData, isLoading } = _useConnectionQueries();
   const { mutateAsync: addRecycleBinItem } = useAddRecycleBinItem();
   const isSoftDeleteModeSetting = useIsSoftDeleteModeSetting();
+  const isQueryTabAutoSaveEnabled = useIsQueryTabAutoSaveEnabled();
 
   function _invalidateQueries() {
+    _connectionQueries = _connectionQueries.map((query, idx) => ({
+      ...query,
+      tabOrder: idx,
+      selected: !!query.selected,
+    }));
     setData(_connectionQueries);
 
     _persistQueries();
   }
 
+  /**
+   * Saves query tabs to backend storage.
+   * @param queryIds - Optional filter; when undefined, every open query tab is saved.
+   * @returns Number of query tabs persisted.
+   * @remarks Auto-save callers pass affected query IDs to avoid writing every tab on every edit; manual `Save All Tabs` intentionally omits it.
+   */
+  const onSaveQueries = async (queryIds?: string[]) => {
+    const idsToSave = queryIds ? new Set(queryIds) : undefined;
+    const queriesToSave = _getPersistableQueries().filter((query) => !idsToSave || idsToSave.has(query.id));
+
+    await Promise.all(queriesToSave.map((query) => dataApi.upsertQuery(query)));
+    return queriesToSave.length;
+  };
+
+  /**
+   * Saves a single query tab to backend storage.
+   * @param queryId - Query tab ID to persist.
+   * @returns Number of query tabs persisted; `0` when no ID is provided.
+   * @remarks Used by explicit manual saves and by auto-save paths that only need to persist one affected tab.
+   */
+  const onSaveQuery = async (queryId?: string) => {
+    if (!queryId) {
+      return 0;
+    }
+
+    return onSaveQueries([queryId]);
+  };
+
   const onAddQueries = async (queries: (SqluiCore.CoreConnectionQuery | undefined)[], options?: { preserveResult?: boolean }) => {
     queries = queries || [];
 
     const res: SqluiCore.CoreConnectionQuery[] = [];
+    const addedQueryIds: string[] = [];
     for (const query of queries) {
       let newQueryData: Partial<SqluiFrontend.ConnectionQuery>;
       if (!query) {
@@ -142,13 +240,15 @@ export function useConnectionQueries() {
           executionStart: options?.preserveResult ? queryAny.executionStart : undefined,
           isSnapshot: options?.preserveResult && !!queryAny.result ? true : undefined,
         };
-        // Strip id so the backend generates one
+        // Strip id so each duplicate/import gets a fresh tab identity.
         delete newQueryData.id;
       }
 
       try {
-        const persisted = await dataApi.upsertQuery(newQueryData as any);
-        const newQuery: SqluiFrontend.ConnectionQuery = { ...newQueryData, id: persisted.id } as any;
+        const newQuery: SqluiFrontend.ConnectionQuery = {
+          ...newQueryData,
+          id: newQueryData.id || getGeneratedRandomId("query"),
+        } as any;
 
         _connectionQueries = [
           ..._connectionQueries.map((q) => ({
@@ -159,6 +259,7 @@ export function useConnectionQueries() {
         ];
 
         res.push(newQuery);
+        addedQueryIds.push(newQuery.id);
       } catch (err) {
         console.error("useConnectionQuery.tsx:upsertQuery", err);
       }
@@ -166,6 +267,9 @@ export function useConnectionQueries() {
 
     try {
       _invalidateQueries();
+      if (isQueryTabAutoSaveEnabled) {
+        await onSaveQueries(addedQueryIds);
+      }
     } catch (err) {
       console.error("useConnectionQuery.tsx:_invalidateQueries", err);
     }
@@ -174,7 +278,7 @@ export function useConnectionQueries() {
   };
 
   const onAddQuery = async (query?: SqluiCore.CoreConnectionQuery, options?: { preserveResult?: boolean }) =>
-    onAddQueries([query], options)[0];
+    (await onAddQueries([query], options))[0];
 
   const onDeleteQueries = async (queryIds?: string[]) => {
     if (!queryIds || queryIds.length === 0) {
@@ -238,8 +342,7 @@ export function useConnectionQueries() {
       _connectionQueries[toBeSelected].selected = true;
     }
 
-    // make an api call to persists
-    // this is fire and forget
+    // remove closed tabs from saved workspace state too, so they do not restore on next launch.
     for (const queryId of queryIds) {
       // make api to delete the query
       dataApi.deleteQuery(queryId);
@@ -257,9 +360,9 @@ export function useConnectionQueries() {
     }));
     _invalidateQueries();
 
-    // persist selected state to the backend so it survives sessionStorage loss
-    for (const q of _connectionQueries) {
-      dataApi.upsertQuery(q);
+    if (isQueryTabAutoSaveEnabled) {
+      // persist selected state to the backend so it survives sessionStorage loss
+      onSaveQuery(queryId);
     }
   };
 
@@ -295,7 +398,12 @@ export function useConnectionQueries() {
 
     try {
       _invalidateQueries();
-      dataApi.upsertQuery(query); // make an api call to persists and this is fire and forget
+      if (isQueryTabAutoSaveEnabled) {
+        const queryToPersist = _getPersistableQueries().find((q) => q.id === query.id);
+        if (queryToPersist) {
+          dataApi.upsertQuery(queryToPersist); // make an api call to persists and this is fire and forget
+        }
+      }
     } catch (err) {
       console.error("useConnectionQuery.tsx:upsertQuery", err);
     }
@@ -322,8 +430,13 @@ export function useConnectionQueries() {
   };
 
   const onChangeTabOrdering = (from: number, to: number) => {
-    _connectionQueries = getUpdatedOrdersForList(_connectionQueries, from, to);
+    const previousQueryIds = _connectionQueries.map((query) => query.id);
+    _connectionQueries = getUpdatedOrdersForList([..._connectionQueries], from, to);
+    const queryIdsWithChangedTabOrder = _getQueryIdsWithChangedTabOrder(previousQueryIds, _connectionQueries);
     _invalidateQueries();
+    if (isQueryTabAutoSaveEnabled) {
+      onSaveQueries(queryIdsWithChangedTabOrder);
+    }
   };
 
   return {
@@ -338,6 +451,8 @@ export function useConnectionQueries() {
     onDuplicateQuery,
     onImportQuery,
     onChangeTabOrdering,
+    onSaveQuery,
+    onSaveQueries,
   };
 }
 

--- a/src/frontend/hooks/useSetting.spec.tsx
+++ b/src/frontend/hooks/useSetting.spec.tsx
@@ -14,6 +14,7 @@ const mockConfigs: any = {
   tablePageSize: "25",
   deleteMode: "soft-delete",
   animationMode: "on",
+  queryTabPersistenceMode: "manual",
 };
 
 vi.mock("src/frontend/hooks/useServerConfigs", () => ({
@@ -34,6 +35,7 @@ import {
   useTableRenderer,
   useWordWrapSetting,
   useQueryTabOrientationSetting,
+  useIsQueryTabAutoSaveEnabled,
   useQuerySizeSetting,
   useTablePageSize,
   useIsSoftDeleteModeSetting,
@@ -81,6 +83,11 @@ describe("useSetting hooks", () => {
   test("useQueryTabOrientationSetting returns horizontal", () => {
     const { result } = renderHook(() => useQueryTabOrientationSetting());
     expect(result.current).toContain("horizontal");
+  });
+
+  test("useIsQueryTabAutoSaveEnabled returns false for manual persistence", () => {
+    const { result } = renderHook(() => useIsQueryTabAutoSaveEnabled());
+    expect(result.current).toBe(false);
   });
 
   test("useQuerySizeSetting returns parsed number", () => {

--- a/src/frontend/hooks/useSetting.tsx
+++ b/src/frontend/hooks/useSetting.tsx
@@ -25,6 +25,7 @@ export function useSetting() {
     animationMode: serverConfigs?.animationMode,
     layoutMode: serverConfigs?.layoutMode,
     querySelectionMode: serverConfigs?.querySelectionMode,
+    queryTabPersistenceMode: serverConfigs?.queryTabPersistenceMode,
     editorMode: serverConfigs?.editorMode,
     editorHeight: serverConfigs?.editorHeight,
     tableRenderer: serverConfigs?.tableRenderer,
@@ -151,6 +152,15 @@ export function useWordWrapSetting() {
 export function useQueryTabOrientationSetting() {
   const { settings } = useSetting();
   return settings?.queryTabOrientation;
+}
+
+/**
+ * Hook returning whether query tabs should be saved automatically.
+ * @returns True unless the user explicitly selects manual query tab persistence.
+ */
+export function useIsQueryTabAutoSaveEnabled() {
+  const { settings } = useSetting();
+  return settings?.queryTabPersistenceMode !== "manual";
 }
 
 /** Default number of rows to return per query execution. */

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -211,6 +211,10 @@ export module SqluiCore {
      * @type {boolean} whether or not a query is pinned and can't be closed
      */
     pinned?: boolean;
+    /** Tab order used when restoring the query workspace. */
+    tabOrder?: number;
+    /** Whether this query tab was selected when the workspace was saved. */
+    selected?: boolean;
     /** Creation timestamp (epoch ms). Auto-set by PersistentStorage on add. */
     createdAt?: number;
     /** Last update timestamp (epoch ms). Auto-set by PersistentStorage on add/update. */
@@ -378,6 +382,7 @@ export module SqluiFrontend {
      */
     querySelectionMode?: "same-tab" | "new-tab";
     deleteMode?: "soft-delete" | "hard-delete";
+    queryTabPersistenceMode?: "auto" | "manual";
   };
 
   /** Valid keys for accessing individual settings. */
@@ -544,5 +549,7 @@ export module SqluiEnums {
     | "clientEvent/showSettings"
     | "clientEvent/tableRenderer"
     | "clientEvent/toggleDevtools"
-    | "clientEvent/toggleSidebar";
+    | "clientEvent/toggleSidebar"
+    | "clientEvent/query/save"
+    | "clientEvent/query/saveAll";
 }


### PR DESCRIPTION
#### Query Tab Persistence

Open query tabs can be restored across app restarts with their query text, tab order, selected tab, and pinned state. In Settings, use `Query Tab Persistence` to choose automatic saving or manual saving via the query tab dropdown's `Save` / `Save All Tabs` actions.