### PR TITLE
fix(test): use :memory: SQLite for relational adapter smoke test

### DIFF
--- a/src/common/adapters/RelationalDataAdapter/index.spec.ts
+++ b/src/common/adapters/RelationalDataAdapter/index.spec.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import createRelationalDataAdapter from "src/common/adapters/RelationalDataAdapter/index";
 
 describe("sqlite", () => {
@@ -9,16 +8,13 @@ describe("sqlite", () => {
   }
 
   beforeAll(() => {
-    const mockedDbFilePath = `mocked-db.sqlite`;
-
-    // try remove the mocked db before starting this test
-    try {
-      fs.unlinkSync(mockedDbFilePath);
-    } catch (err) {
-      console.error("index.spec.ts:unlinkSync", err);
-    }
-
-    adapter = createRelationalDataAdapter(`sqlite://${mockedDbFilePath}`);
+    // Use an in-memory SQLite DB so the test is self-contained and bypasses the
+    // file-state classifier (added in 77da1cad), which now throws "SQLite file
+    // not found" for paths that don't yet exist. The same adapter instance is
+    // reused across the tests below, so the in-memory data persists between
+    // them on a single shared connection. File-based behavior is covered
+    // separately by sqlite/index.spec.ts.
+    adapter = createRelationalDataAdapter(`sqlite://:memory:`);
   });
 
   test("Create and insert table", async () => {


### PR DESCRIPTION
## Summary
- Main build is red: 4 sqlite tests in `src/common/adapters/RelationalDataAdapter/index.spec.ts` fail with `SQLite file not found at: mocked-db.sqlite`.
- Root cause: 77da1cad added a strict pre-flight file classifier that now throws on missing paths *before* the first `execute(CREATE TABLE ...)` can auto-create the file. The old test relied on the legacy auto-create behavior.
- Fix: switch the test to `sqlite://:memory:` — bypasses the classifier and keeps the existing shared-connection / shared-state pattern (one adapter, five tests). File-based validation paths remain covered by `sqlite/index.spec.ts`.

## Test plan
- [x] `npx vitest run src/common/adapters/RelationalDataAdapter/index.spec.ts` — 5/5 pass
- [x] `npx vitest run src/common/adapters/RelationalDataAdapter/sqlite/` — 6/6 still pass (no regression to the new file-validation tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)