### PR TITLE
bump version to 3.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "3.1.13",
+      "version": "3.1.14",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
- Bumps app version 3.1.13 → 3.1.14 in package.json, package-lock.json, src-tauri/tauri.conf.json.
- Patch release to ship the latest main (native save + reveal-in-finder toast for result downloads).

## Test plan
- [x] CI green
- [ ] Release Official workflow produces v3.1.14 artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)