### PR TITLE
chore: remove dead Redis TODO comments

### DIFF
--- a/src/frontend/components/MigrationBox/index.tsx
+++ b/src/frontend/components/MigrationBox/index.tsx
@@ -212,8 +212,6 @@ export async function generateMigrationScript(
       res.push(formatJS(getCreateDatabaseForMongoDB(toQueryMetaData)?.query || ""));
       res.push(formatJS(getCreateCollectionForMongoDB(toQueryMetaData)?.query || ""));
       break;
-    // case 'redis': // TODO: to be implemented
-    // case 'rediss': // TODO: to be implemented
     case "cosmosdb":
       res.push(`// Schema Creation Script : ${migrationInfoMessage}`);
       res.push(formatJS(getCreateDatabaseForAzCosmosDb(toQueryMetaData)?.query || ""));
@@ -293,8 +291,6 @@ export async function generateMigrationScript(
           errors.push(MESSAGE_NO_DATA_FOR_MIGRATION);
         }
         break;
-      // case 'redis': // TODO: to be implemented
-      // case 'rediss': // TODO: to be implemented
       case "cosmosdb":
         res.push(`// Data Migration Script`);
         if (hasSomeResults) {
@@ -731,8 +727,6 @@ function MigrationMetaDataInputs(props: MigrationMetaDataInputsProps): React.JSX
 
   let shouldShowNewDatabaseIdInput = true;
   switch (migrationMetaData.toDialect) {
-    // case 'redis': // TODO: to be implemented
-    // case 'rediss': // TODO: to be implemented
     case "mysql":
     case "mariadb":
     case "mssql":

--- a/src/frontend/views/RecordPage/index.tsx
+++ b/src/frontend/views/RecordPage/index.tsx
@@ -181,8 +181,6 @@ function RecordForm(props) {
           newData = props.data;
           break;
         case "mongodb":
-        // case 'redis': // TODO: to be implemented
-        // case 'rediss': // TODO: to be implemented
         case "cosmosdb":
           newRawValue = { ...props.data };
           break;
@@ -225,8 +223,6 @@ function RecordForm(props) {
           }
           setRawValue(JSON.stringify(newData, null, 2));
           break;
-        // case 'redis': // TODO: to be implemented
-        // case 'rediss': // TODO: to be implemented
         case "cosmosdb":
           for (const column of columns.filter((targetColumn) => targetColumn.name[0] !== "_" && !targetColumn.primaryKey)) {
             set(newData, column.propertyPath || column.name, "");
@@ -341,8 +337,6 @@ function RecordForm(props) {
         }
         break;
       case "mongodb":
-      // case 'redis': // TODO: to be implemented
-      // case 'rediss': // TODO: to be implemented
       case "cosmosdb":
       case "aztable":
         // js raw value
@@ -474,8 +468,6 @@ export function NewRecordPage() {
           return;
         }
         break;
-      // case 'redis': // TODO: to be implemented
-      // case 'rediss': // TODO: to be implemented
       case "cosmosdb":
         try {
           const jsonValue = JSON.parse(rawValue);
@@ -687,8 +679,6 @@ export function EditRecordPage(props: RecordDetailsPageProps): React.JSX.Element
           return;
         }
         break;
-      // case 'redis': // TODO: to be implemented
-      // case 'rediss': // TODO: to be implemented
       case "cosmosdb":
         try {
           const jsonValue = JSON.parse(rawValue);


### PR DESCRIPTION
## Summary
- Removes unreachable `// case 'redis':` / `// case 'rediss':` switch-case comments from `RecordPage/index.tsx` and `MigrationBox/index.tsx`.
- These cases were never executed: Redis opts out via `supportCreateRecordForm`, `supportEditRecordForm`, and `supportMigration` returning `false`.
- Reduces visual noise; no behavior change.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Affected specs still pass