### PR TITLE
fix: surface recycle-bin backup failures

### DIFF
--- a/src/frontend/hooks/useConnection.hooks.spec.tsx
+++ b/src/frontend/hooks/useConnection.hooks.spec.tsx
@@ -28,6 +28,10 @@ vi.mock("src/frontend/hooks/useSetting", () => ({
   useIsSoftDeleteModeSetting: () => false,
 }));
 
+vi.mock("src/frontend/hooks/useToaster", () => ({
+  default: () => ({ add: vi.fn().mockResolvedValue({ dismiss: vi.fn() }), dismiss: vi.fn() }),
+}));
+
 vi.mock("src/frontend/utils/commonUtils", async () => {
   const actual = await vi.importActual<any>("src/frontend/utils/commonUtils");
   return {

--- a/src/frontend/hooks/useConnection.tsx
+++ b/src/frontend/hooks/useConnection.tsx
@@ -5,6 +5,7 @@ import dataApi from "src/frontend/data/api";
 import { useAddRecycleBinItem } from "src/frontend/hooks/useFolderItems";
 import { queryKeys } from "src/frontend/hooks/queryKeys";
 import { useIsSoftDeleteModeSetting } from "src/frontend/hooks/useSetting";
+import useToaster from "src/frontend/hooks/useToaster";
 import { getUpdatedOrdersForList } from "src/frontend/utils/commonUtils";
 import { SqluiCore, SqluiFrontend } from "typings";
 
@@ -102,6 +103,7 @@ export function useUpsertConnection() {
 
 /**
  * Hook to delete a connection. Optionally backs up to recycle bin if soft delete is enabled.
+ * On recycle-bin backup failure, the deletion still proceeds; the user is notified via toast.
  * @returns Mutation that accepts a connection ID to delete.
  */
 export function useDeleteConnection() {
@@ -109,6 +111,7 @@ export function useDeleteConnection() {
   const { mutateAsync: addRecycleBinItem } = useAddRecycleBinItem();
   const { data: connections } = useGetConnections();
   const isSoftDeleteModeSetting = useIsSoftDeleteModeSetting();
+  const { add: addToast } = useToaster();
 
   return useMutation<string, void, string>({
     mutationFn: dataApi.deleteConnection,
@@ -134,7 +137,8 @@ export function useDeleteConnection() {
         }
       } catch (err) {
         console.error("useConnection.tsx:addRecycleBinItem", err);
-        // TODO: add error handling
+        // Surface failure to user without aborting the deletion (already committed above).
+        addToast({ message: "Failed to back up connection to recycle bin" });
       }
 
       return deletedConnectionId;

--- a/src/frontend/hooks/useSession.extra.spec.tsx
+++ b/src/frontend/hooks/useSession.extra.spec.tsx
@@ -34,6 +34,10 @@ vi.mock("src/frontend/hooks/useSetting", () => ({
   useIsSoftDeleteModeSetting: () => true,
 }));
 
+vi.mock("src/frontend/hooks/useToaster", () => ({
+  default: () => ({ add: vi.fn().mockResolvedValue({ dismiss: vi.fn() }), dismiss: vi.fn() }),
+}));
+
 import dataApi from "src/frontend/data/api";
 import { useSelectSession, useUpsertSession, useDeleteSession, useCloneSession } from "src/frontend/hooks/useSession";
 

--- a/src/frontend/hooks/useSession.spec.tsx
+++ b/src/frontend/hooks/useSession.spec.tsx
@@ -28,6 +28,10 @@ vi.mock("src/frontend/hooks/useSetting", () => ({
   useIsSoftDeleteModeSetting: () => false,
 }));
 
+vi.mock("src/frontend/hooks/useToaster", () => ({
+  default: () => ({ add: vi.fn().mockResolvedValue({ dismiss: vi.fn() }), dismiss: vi.fn() }),
+}));
+
 vi.mock("src/frontend/utils/commonUtils", () => ({
   useNavigate: () => vi.fn(),
 }));

--- a/src/frontend/hooks/useSession.tsx
+++ b/src/frontend/hooks/useSession.tsx
@@ -4,6 +4,7 @@ import dataApi from "src/frontend/data/api";
 import { getCurrentSessionId, setCurrentSessionId } from "src/frontend/data/session";
 import { useAddRecycleBinItem } from "src/frontend/hooks/useFolderItems";
 import { useIsSoftDeleteModeSetting } from "src/frontend/hooks/useSetting";
+import useToaster from "src/frontend/hooks/useToaster";
 import { SqluiCore } from "typings";
 
 /** React Query cache key for sessions. */
@@ -92,6 +93,7 @@ export function useCloneSession() {
 
 /**
  * Hook to delete a session. Optionally backs up session and its connections to recycle bin.
+ * On recycle-bin backup failure, the deletion still proceeds; the user is notified via toast.
  * @returns Mutation that accepts a session ID to delete.
  */
 export function useDeleteSession() {
@@ -99,6 +101,7 @@ export function useDeleteSession() {
   const { mutateAsync: addRecycleBinItem } = useAddRecycleBinItem();
   const { data: sessions } = useGetSessions();
   const isSoftDeleteModeSetting = useIsSoftDeleteModeSetting();
+  const { add: addToast } = useToaster();
 
   return useMutation<{ deletedSessionId: string; connections: SqluiCore.ConnectionProps[] }, void, string>({
     mutationFn: async (sessionId: string) => {
@@ -137,7 +140,8 @@ export function useDeleteSession() {
         }
       } catch (err) {
         console.error("useSession.tsx:addRecycleBinItem", err);
-        // TODO: add error handling
+        // Surface failure to user without aborting the deletion (already committed above).
+        addToast({ message: "Failed to back up session to recycle bin" });
       }
 
       return deletedSessionId;


### PR DESCRIPTION
## Summary

- `useDeleteConnection` and `useDeleteSession` previously swallowed recycle-bin backup failures with a bare `// TODO: add error handling` comment.
- Replaced the silent swallow with a non-blocking toast via the existing `useToaster` hook (no new deps).
- Deletion still proceeds even when backup fails — only behavior change is that the user is now informed.
- `console.error` kept per repo convention.

## Test plan

- [x] `npx vitest run src/frontend/hooks/useConnection src/frontend/hooks/useSession` — all 47 tests pass (extended existing mocks with `useToaster`).
- [x] `npm run typecheck` clean.
- [ ] Manual: trigger a backup failure in soft-delete mode → toast appears with "Failed to back up connection/session to recycle bin".

🤖 Generated with [Claude Code](https://claude.com/claude-code)