### PR TITLE
fix: monaco editor stops responding to keypresses after tab churn (v4.0.0)

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -124,6 +124,21 @@ async function typeInEditor(page: Page, text: string) {
   await page.waitForTimeout(300);
 }
 
+/** Reads the current text of the visible QueryBox Monaco editor. */
+async function readEditorValue(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const queryBoxEl = document.querySelector(".CodeEditorBox__QueryBox");
+    const allEditors = (window as any).monaco?.editor?.getEditors() || [];
+    const editor = allEditors.find((e: any) => {
+      try {
+        return queryBoxEl?.contains(e.getDomNode());
+      } catch {
+        return false;
+      }
+    });
+    return editor?.getValue() ?? "";
+  });
+}
 /** Clicks execute and waits for results (SQL queries). */
 async function executeQuery(page: Page) {
   await page.locator("#btnExecuteCommand").click();
@@ -378,6 +393,72 @@ test.describe("Phase 4: Query Tabs", () => {
     await page.getByRole("menuitem", { name: "Duplicate" }).click();
 
     await expect(queryTabs).toHaveCount(tabsBefore + 1, { timeout: 5_000 });
+  });
+
+  test("editor still responds to keypresses after heavy tab churn", async ({ page }) => {
+    // Regression: AdvancedEditor never disposed its Monaco editor on unmount, so every tab switch
+    // leaked a live editor into Monaco's global registry. A leaked editor that was focused when it
+    // was removed from the DOM keeps reporting hasTextFocus() === true (Chromium fires no blur for
+    // a removed node), wins getFocusedCodeEditor(), and swallows every keybinding-driven key.
+    const queryTabs = page.locator("#QueryBoxTabs > .Tab__Headers [role='tab']:not(:last-child)");
+    const addTab = page.getByRole("tab", { name: "Add Query" });
+    const tabsBefore = await queryTabs.count();
+
+    await addTab.click();
+    await expect(queryTabs).toHaveCount(tabsBefore + 1, { timeout: 10_000 });
+    await addTab.click();
+    await expect(queryTabs).toHaveCount(tabsBefore + 2, { timeout: 10_000 });
+
+    await queryTabs.first().click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Duplicate" }).click();
+    await expect(queryTabs).toHaveCount(tabsBefore + 3, { timeout: 10_000 });
+
+    // bounce back and forth to churn the editor mount/unmount cycle, which is the reported repro
+    const totalTabs = await queryTabs.count();
+    for (let pass = 0; pass < 3; pass++) {
+      for (let idx = 0; idx < totalTabs; idx++) {
+        await queryTabs.nth(idx).click();
+        await page.waitForTimeout(100);
+      }
+    }
+
+    // Only the active tab renders a body, so the registry must not grow with the number of visits.
+    const editorStats = await page.evaluate(() => {
+      const editors = (window as any).monaco?.editor?.getEditors() || [];
+      const detachedFocused = editors.filter((e: any) => {
+        try {
+          return !document.body.contains(e.getDomNode()) && e.hasTextFocus();
+        } catch {
+          return false;
+        }
+      }).length;
+      return { total: editors.length, detachedFocused };
+    });
+    expect(editorStats.total).toBeLessThanOrEqual(2);
+    expect(editorStats.detachedFocused).toBe(0);
+
+    const editorContainer = page.locator(".CodeEditorBox__QueryBox .monaco-editor").first();
+    await expect(editorContainer).toBeVisible({ timeout: 10_000 });
+
+    await typeInEditor(page, "");
+    await editorContainer.click();
+    await page.waitForTimeout(200);
+
+    // plain typing
+    await page.keyboard.type("select 1234");
+    await page.waitForTimeout(300);
+    expect(await readEditorValue(page)).toContain("select 1234");
+
+    // keybinding-dispatched keys — these are what a hijacked getFocusedCodeEditor() swallows
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(300);
+    expect(await readEditorValue(page)).toContain("select 12");
+
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("from t");
+    await page.waitForTimeout(300);
+    expect(await readEditorValue(page)).toContain("\nfrom t");
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "3.1.14",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "3.1.14",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "3.1.14",
+  "version": "4.0.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "3.1.14",
+  "version": "4.0.0",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",

--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.spec.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.spec.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const createdEditors: any[] = [];
+  const createdModels: any[] = [];
+
+  /** Builds a fake Monaco text model with just enough surface for AdvancedEditor. */
+  const makeModel = (value: string, language?: string) => {
+    const model: any = {
+      value,
+      language,
+      disposed: false,
+      attachedCount: 0,
+      isDisposed: () => model.disposed,
+      isAttachedToEditor: () => model.attachedCount > 0,
+      dispose: () => {
+        model.disposed = true;
+      },
+      getValue: () => model.value,
+      setValue: (newValue: string) => {
+        model.value = newValue;
+      },
+      getFullModelRange: () => ({ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 }),
+      getLineCount: () => 1,
+      getLineMaxColumn: () => model.value.length + 1,
+      getPositionAt: () => ({ lineNumber: 1, column: 1 }),
+      getValueInRange: () => model.value,
+      getWordUntilPosition: () => ({ startColumn: 1, endColumn: 1 }),
+      onDidChangeContent: () => ({ dispose: () => {} }),
+    };
+    createdModels.push(model);
+    return model;
+  };
+
+  const monaco: any = {
+    editor: {
+      create: vi.fn((_container: HTMLElement, options: any) => {
+        const editor: any = {
+          options,
+          model: options.model,
+          disposed: false,
+          getModel: () => editor.model,
+          setModel: (newModel: any) => {
+            editor.model = newModel;
+          },
+          getValue: () => editor.model?.getValue() ?? "",
+          setValue: (newValue: string) => editor.model?.setValue(newValue),
+          dispose: vi.fn(() => {
+            editor.disposed = true;
+            if (editor.model) editor.model.attachedCount--;
+          }),
+          updateOptions: vi.fn(),
+          onDidBlurEditorWidget: vi.fn(() => ({ dispose: () => {} })),
+          onDidChangeModelContent: vi.fn(() => ({ dispose: () => {} })),
+          getSelection: () => null,
+          setSelection: vi.fn(),
+          getPosition: () => ({ lineNumber: 1, column: 1 }),
+          executeEdits: vi.fn((_source: any, edits: any[]) => editor.model?.setValue(edits[0].text)),
+          pushUndoStop: vi.fn(),
+          deltaDecorations: vi.fn(() => []),
+        };
+        if (editor.model) editor.model.attachedCount++;
+        createdEditors.push(editor);
+        return editor;
+      }),
+      createModel: vi.fn((value: string, language?: string) => makeModel(value, language)),
+      setTheme: vi.fn(),
+      setModelLanguage: vi.fn(),
+    },
+    languages: {
+      CompletionItemKind: { Module: 1, Struct: 2, Field: 3, Variable: 4 },
+      registerCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    Range: class {},
+    Selection: class {},
+  };
+
+  return { monaco, createdEditors, createdModels };
+});
+
+vi.mock("src/frontend/monacoSetup", () => ({ monaco: mocks.monaco, default: mocks.monaco }));
+
+vi.mock("src/frontend/hooks/useSetting", () => ({
+  useDarkModeSetting: () => "light",
+  useEditorModeSetting: () => "advanced",
+  useWordWrapSetting: () => false,
+}));
+
+import AdvancedEditor from "src/frontend/components/CodeEditorBox/AdvancedEditor";
+import { getEditorModelCacheSize, releaseEditorModel, resetEditorModelCache } from "src/frontend/components/CodeEditorBox/editorModelCache";
+
+describe("AdvancedEditor", () => {
+  beforeEach(() => {
+    resetEditorModelCache();
+    mocks.createdEditors.length = 0;
+    mocks.createdModels.length = 0;
+    mocks.monaco.editor.create.mockClear();
+    mocks.monaco.editor.createModel.mockClear();
+    mocks.monaco.editor.setTheme.mockClear();
+    mocks.monaco.editor.setModelLanguage.mockClear();
+  });
+
+  test("disposes the editor on unmount so it leaves Monaco's global editor registry", () => {
+    // Regression: the old teardown closed over `editor` from the first render (always null) so
+    // dispose() never ran. Leaked editors keep winning getFocusedCodeEditor() and swallow keys.
+    const { unmount } = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+
+    expect(mocks.createdEditors).toHaveLength(1);
+    expect(mocks.createdEditors[0].disposed).toBe(false);
+
+    unmount();
+
+    expect(mocks.createdEditors[0].disposed).toBe(true);
+  });
+
+  test("create count matches dispose count across repeated tab switches", () => {
+    for (let i = 0; i < 10; i++) {
+      const { unmount } = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+      unmount();
+    }
+
+    expect(mocks.createdEditors).toHaveLength(10);
+    expect(mocks.createdEditors.every((editor) => editor.disposed)).toBe(true);
+  });
+
+  test("keeps the model alive across unmount and reuses it on remount", () => {
+    const first = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+    const model = mocks.createdEditors[0].model;
+
+    first.unmount();
+
+    // disposing the editor must NOT dispose the model — that is what preserves the undo stack
+    expect(model.disposed).toBe(false);
+    expect(model.isAttachedToEditor()).toBe(false);
+    expect(getEditorModelCacheSize()).toBe(1);
+
+    mocks.monaco.editor.createModel.mockClear();
+    const second = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+
+    expect(mocks.monaco.editor.createModel).not.toHaveBeenCalled();
+    expect(mocks.createdEditors[1].model).toBe(model);
+    // while mounted the model is out of the cache, so it can never be evicted from under a live editor
+    expect(getEditorModelCacheSize()).toBe(0);
+
+    second.unmount();
+  });
+
+  test("does not reuse a disposed model", () => {
+    const first = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+    const model = mocks.createdEditors[0].model;
+    first.unmount();
+
+    model.disposed = true;
+    mocks.monaco.editor.createModel.mockClear();
+
+    const second = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+
+    expect(mocks.monaco.editor.createModel).toHaveBeenCalledTimes(1);
+    expect(mocks.createdEditors[1].model).not.toBe(model);
+
+    second.unmount();
+  });
+
+  test("disposes the model of an editor that has no id", () => {
+    const { unmount } = render(<AdvancedEditor value="SELECT 1" language="sql" />);
+    const model = mocks.createdEditors[0].model;
+
+    unmount();
+
+    expect(model.disposed).toBe(true);
+    expect(getEditorModelCacheSize()).toBe(0);
+  });
+
+  test("applies language, word wrap and theme in place instead of recreating the editor", () => {
+    const { rerender, unmount } = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" wordWrap={false} />);
+
+    expect(mocks.monaco.editor.create).toHaveBeenCalledTimes(1);
+    const editor = mocks.createdEditors[0];
+
+    rerender(<AdvancedEditor id="query-1" value="SELECT 1" language="javascript" wordWrap={true} />);
+
+    // still a single editor — recreating it is what leaked zombies in the first place
+    expect(mocks.monaco.editor.create).toHaveBeenCalledTimes(1);
+    expect(editor.disposed).toBe(false);
+    expect(mocks.monaco.editor.setModelLanguage).toHaveBeenCalledWith(editor.model, "javascript");
+    expect(editor.updateOptions).toHaveBeenCalledWith(expect.objectContaining({ wordWrap: "on" }));
+    expect(mocks.monaco.editor.setTheme).toHaveBeenCalledWith("light");
+
+    unmount();
+  });
+
+  test("discards rather than parks the model when the id was released while mounted", () => {
+    const { unmount } = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" />);
+    const model = mocks.createdEditors[0].model;
+
+    // closing the query tab happens before React unmounts the editor
+    releaseEditorModel("query-1");
+    unmount();
+
+    expect(model.disposed).toBe(true);
+    expect(getEditorModelCacheSize()).toBe(0);
+  });
+
+  test("exposes selection and value helpers through editorRef", () => {
+    const editorRef = { current: undefined } as any;
+    const { unmount } = render(<AdvancedEditor id="query-1" value="SELECT 1" language="sql" editorRef={editorRef} />);
+
+    expect(editorRef.current?.getValue()).toBe("SELECT 1");
+
+    unmount();
+  });
+});

--- a/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
+++ b/src/frontend/components/CodeEditorBox/AdvancedEditor.tsx
@@ -3,6 +3,12 @@ import { monaco } from "src/frontend/monacoSetup";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { styled } from "@mui/system";
 import { CompletionItem, DecoratedEditorProps as AdvancedEditorProps, EditorVariable } from "src/frontend/components/CodeEditorBox";
+import {
+  cacheEditorModel,
+  consumeReleasedEditorId,
+  disposeEditorModel,
+  takeCachedEditorModel,
+} from "src/frontend/components/CodeEditorBox/editorModelCache";
 import { useDarkModeSetting } from "src/frontend/hooks/useSetting";
 
 const AdvancedEditorContainer = styled("div")(() => {
@@ -22,10 +28,13 @@ const DEFAULT_OPTIONS = {
   },
 };
 
-const EDITOR_MODELS_MAP: Record<string, any> = {};
-
 /**
  * Monaco-based code editor with undo/redo stack preservation, dark mode support, and selection text retrieval.
+ *
+ * The editor instance is created exactly once per mount and is always disposed on unmount. Option
+ * changes (theme, word wrap, language, read-only) are applied in place rather than by recreating
+ * the editor, because a leaked Monaco editor stays registered in Monaco's global editor registry
+ * and can hijack `getFocusedCodeEditor()`, which silently swallows keybindings in the visible editor.
  * @param props - Editor configuration including value, language, word wrap, and editor ref.
  * @returns The rendered Monaco editor container.
  */
@@ -33,7 +42,6 @@ export default function AdvancedEditor(props: AdvancedEditorProps): React.JSX.El
   const colorMode = useDarkModeSetting();
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoEl = useRef(null);
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const decorationIdsRef = useRef<string[]>([]);
   /** True during programmatic value sync — suppresses onDidChangeModelContent callbacks. */
   const suppressChangeRef = useRef(false);
@@ -48,64 +56,21 @@ export default function AdvancedEditor(props: AdvancedEditorProps): React.JSX.El
   const valueRef = useRef(props.value);
   valueRef.current = props.value;
 
-  const onSetupMonacoEditor = useCallback(() => {
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-    debounceTimerRef.current = setTimeout(() => {
-      editor?.dispose();
+  // Refs read by the create/teardown effect, which intentionally runs only once per mount.
+  const idRef = useRef(props.id);
+  idRef.current = props.id;
+  const languageRef = useRef(props.language);
+  languageRef.current = props.language;
+  const wordWrapRef = useRef(props.wordWrap);
+  wordWrapRef.current = props.wordWrap;
+  const readOnlyRef = useRef(props.readOnly);
+  readOnlyRef.current = props.readOnly;
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
 
-      if (monacoEl.current) {
-        const newEditor = monaco.editor.create(monacoEl.current!, {
-          value: valueRef.current,
-          language: props.language,
-          theme: colorMode === "dark" ? "vs-dark" : "light",
-          wordWrap: props.wordWrap === true ? "on" : "off",
-          readOnly: !!props.readOnly,
-          ...DEFAULT_OPTIONS,
-        });
+  /** Resolves the Monaco theme name for the current color mode. */
+  const getThemeName = useCallback((mode: string | undefined) => (mode === "dark" ? "vs-dark" : "light"), []);
 
-        newEditor.onDidBlurEditorWidget(() => {
-          onBlurRef.current?.(newEditor.getValue() || "");
-        });
-
-        newEditor.onDidChangeModelContent(() => {
-          if (suppressChangeRef.current) return;
-          hasPendingChangeRef.current = true;
-          onLiveChangeRef.current?.(newEditor.getValue() || "");
-        });
-
-        // clean up the model as we don't need it while it's active
-        if (props.id && EDITOR_MODELS_MAP[props.id]) {
-          newEditor.setModel(EDITOR_MODELS_MAP[props.id]);
-          delete EDITOR_MODELS_MAP[props.id];
-        }
-
-        hasPendingChangeRef.current = false;
-        setEditor(newEditor);
-      }
-    }, 100);
-  }, [editor, props.language, props.wordWrap, props.id, colorMode]);
-
-  // this is used to clean up the editor
-  useEffect(() => {
-    return () => {
-      // dispose the editor
-      editor?.dispose();
-      setEditor(null);
-    };
-  }, []);
-
-  // this is used to clean up the editor
-  useEffect(() => {
-    return () => {
-      // keep track of the undo if we need it
-      if (editor && props.id) {
-        // https://stackoverflow.com/questions/48210120/get-restore-monaco-editor-undoredo-stack
-        EDITOR_MODELS_MAP[props.id] = editor?.getModel();
-      }
-    };
-  }, [editor, props.id]);
   // Sync external value changes to the editor (e.g., loading a saved query, applying a template).
   // Skips when the editor already has the same content (round-trip from user typing)
   // or when the editor has pending user-initiated changes (debounce hasn't settled).
@@ -177,6 +142,27 @@ export default function AdvancedEditor(props: AdvancedEditorProps): React.JSX.El
       };
     }
   }, [editor, props.editorRef]);
+
+  // Apply the theme in place. Monaco's standalone theme service is global, so this is the same
+  // scope the `theme` construction option had.
+  useEffect(() => {
+    monaco.editor.setTheme(getThemeName(colorMode));
+  }, [colorMode, getThemeName]);
+
+  // Apply word wrap / read-only in place instead of recreating the editor.
+  useEffect(() => {
+    editor?.updateOptions({
+      wordWrap: props.wordWrap === true ? "on" : "off",
+      readOnly: !!props.readOnly,
+    });
+  }, [editor, props.wordWrap, props.readOnly]);
+
+  // Apply the language in place instead of recreating the editor.
+  useEffect(() => {
+    const model = editor?.getModel();
+    if (!model || model.isDisposed() || !props.language) return;
+    monaco.editor.setModelLanguage(model, props.language);
+  }, [editor, props.language]);
 
   // register autocomplete suggestions from connection metadata
   useEffect(() => {
@@ -264,7 +250,9 @@ export default function AdvancedEditor(props: AdvancedEditorProps): React.JSX.El
     const disposable = model.onDidChangeContent(() => updateDecorations());
     return () => {
       disposable.dispose();
-      if (editor) {
+      // The model is parked for reuse, so strip the decorations we added rather than leaving
+      // stale ranges behind for the next mount.
+      if (!model.isDisposed()) {
         decorationIdsRef.current = editor.deltaDecorations(decorationIdsRef.current, []);
       }
     };
@@ -314,9 +302,62 @@ export default function AdvancedEditor(props: AdvancedEditorProps): React.JSX.El
     return () => disposable.dispose();
   }, [props.variables, props.language]);
 
-  // here we will initiate the editor
-  // and can be also be used to update the settings
-  useEffect(onSetupMonacoEditor, [monacoEl, props.wordWrap, props.language, colorMode]);
+  // Create the editor once per mount and always dispose it on unmount.
+  //
+  // This effect is declared last on purpose: React runs cleanups in declaration order, so every
+  // effect above releases its Monaco disposables while the editor is still alive.
+  useEffect(() => {
+    const container = monacoEl.current;
+    if (!container) return;
+
+    const id = idRef.current;
+
+    // We create and own the model so that `editor.dispose()` does not dispose it — Monaco only
+    // disposes a model it created itself (StandaloneEditor._ownsModel). That is what lets the
+    // undo stack survive an unmount.
+    const restoredModel = takeCachedEditorModel(id);
+    const model = restoredModel ?? monaco.editor.createModel(valueRef.current || "", languageRef.current);
+
+    const newEditor = monaco.editor.create(container, {
+      model,
+      theme: getThemeName(colorModeRef.current),
+      wordWrap: wordWrapRef.current === true ? "on" : "off",
+      readOnly: !!readOnlyRef.current,
+      ...DEFAULT_OPTIONS,
+    });
+
+    newEditor.onDidBlurEditorWidget(() => {
+      onBlurRef.current?.(newEditor.getValue() || "");
+    });
+
+    newEditor.onDidChangeModelContent(() => {
+      if (suppressChangeRef.current) return;
+      hasPendingChangeRef.current = true;
+      onLiveChangeRef.current?.(newEditor.getValue() || "");
+    });
+
+    hasPendingChangeRef.current = false;
+    setEditor(newEditor);
+
+    return () => {
+      const currentId = idRef.current;
+      const currentModel = newEditor.getModel();
+
+      newEditor.dispose();
+      setEditor(null);
+
+      if (!currentModel || currentModel.isDisposed()) {
+        return;
+      }
+
+      if (currentId && !consumeReleasedEditorId(currentId)) {
+        cacheEditorModel(currentId, currentModel);
+        return;
+      }
+
+      disposeEditorModel(currentModel);
+    };
+  }, [getThemeName]);
 
   return (
     <AdvancedEditorContainer

--- a/src/frontend/components/CodeEditorBox/editorModelCache.spec.ts
+++ b/src/frontend/components/CodeEditorBox/editorModelCache.spec.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import type { editor } from "monaco-editor";
+import {
+  MAX_CACHED_MODELS,
+  cacheEditorModel,
+  consumeReleasedEditorId,
+  disposeEditorModel,
+  getEditorModelCacheSize,
+  releaseEditorModel,
+  resetEditorModelCache,
+  takeCachedEditorModel,
+} from "src/frontend/components/CodeEditorBox/editorModelCache";
+
+type FakeModel = editor.ITextModel & { disposed: boolean; attached: boolean };
+
+function createFakeModel(options?: { attached?: boolean; disposed?: boolean }): FakeModel {
+  const model = {
+    disposed: !!options?.disposed,
+    attached: !!options?.attached,
+    isDisposed() {
+      return model.disposed;
+    },
+    isAttachedToEditor() {
+      return model.attached;
+    },
+    dispose() {
+      model.disposed = true;
+    },
+  };
+  return model as unknown as FakeModel;
+}
+
+describe("editorModelCache", () => {
+  beforeEach(() => {
+    resetEditorModelCache();
+  });
+
+  test("parks and restores a model by id", () => {
+    const model = createFakeModel();
+    cacheEditorModel("query-1", model);
+
+    expect(getEditorModelCacheSize()).toBe(1);
+    expect(takeCachedEditorModel("query-1")).toBe(model);
+    // taking the model removes it, so the cache only ever holds detached models
+    expect(getEditorModelCacheSize()).toBe(0);
+    expect(takeCachedEditorModel("query-1")).toBeUndefined();
+  });
+
+  test("never restores a disposed model", () => {
+    const model = createFakeModel({ disposed: true });
+    cacheEditorModel("query-1", model);
+
+    expect(takeCachedEditorModel("query-1")).toBeUndefined();
+    expect(getEditorModelCacheSize()).toBe(0);
+  });
+
+  test("returns undefined for an anonymous editor", () => {
+    expect(takeCachedEditorModel(undefined)).toBeUndefined();
+  });
+
+  test("evicts and disposes the least recently used model past the cap", () => {
+    const oldest = createFakeModel();
+    cacheEditorModel("query-oldest", oldest);
+
+    for (let i = 0; i < MAX_CACHED_MODELS; i++) {
+      cacheEditorModel(`query-${i}`, createFakeModel());
+    }
+
+    expect(getEditorModelCacheSize()).toBe(MAX_CACHED_MODELS);
+    expect(oldest.disposed).toBe(true);
+    expect(takeCachedEditorModel("query-oldest")).toBeUndefined();
+  });
+
+  test("re-parking an id refreshes its recency instead of duplicating it", () => {
+    const model = createFakeModel();
+    cacheEditorModel("query-1", model);
+    cacheEditorModel("query-1", model);
+
+    expect(getEditorModelCacheSize()).toBe(1);
+    expect(model.disposed).toBe(false);
+  });
+
+  test("eviction never disposes a model that is still attached to an editor", () => {
+    const attached = createFakeModel({ attached: true });
+    cacheEditorModel("query-attached", attached);
+
+    for (let i = 0; i < MAX_CACHED_MODELS; i++) {
+      cacheEditorModel(`query-${i}`, createFakeModel());
+    }
+
+    expect(attached.disposed).toBe(false);
+  });
+
+  test("disposeEditorModel skips missing, disposed, and attached models", () => {
+    const attached = createFakeModel({ attached: true });
+    disposeEditorModel(attached);
+    expect(attached.disposed).toBe(false);
+
+    const detached = createFakeModel();
+    disposeEditorModel(detached);
+    expect(detached.disposed).toBe(true);
+
+    expect(() => disposeEditorModel(undefined)).not.toThrow();
+  });
+
+  test("releaseEditorModel disposes a parked model right away", () => {
+    const model = createFakeModel();
+    cacheEditorModel("query-1", model);
+
+    releaseEditorModel("query-1");
+
+    expect(model.disposed).toBe(true);
+    expect(getEditorModelCacheSize()).toBe(0);
+    expect(consumeReleasedEditorId("query-1")).toBe(false);
+  });
+
+  test("releaseEditorModel tombstones an id whose editor is still mounted", () => {
+    // nothing parked yet — the editor still holds the model
+    releaseEditorModel("query-live");
+
+    expect(consumeReleasedEditorId("query-live")).toBe(true);
+    // the marker is consumed exactly once
+    expect(consumeReleasedEditorId("query-live")).toBe(false);
+  });
+});

--- a/src/frontend/components/CodeEditorBox/editorModelCache.ts
+++ b/src/frontend/components/CodeEditorBox/editorModelCache.ts
@@ -1,0 +1,108 @@
+/** Cache of detached Monaco text models, keyed by editor id, used to preserve undo/redo stacks. */
+import type { editor } from "monaco-editor";
+
+/** A Monaco text model. Imported as a type only so this module has no runtime Monaco dependency. */
+type TextModel = editor.ITextModel;
+
+/** Maximum number of detached models parked for undo-stack preservation. */
+export const MAX_CACHED_MODELS = 50;
+
+/**
+ * Detached Monaco text models parked by editor id so closing and reopening a query tab keeps its
+ * undo/redo stack. Invariant: this map only ever holds models that are NOT attached to a live
+ * editor — a model is taken out of the map while its editor is mounted and put back on unmount.
+ */
+const EDITOR_MODELS_MAP = new Map<string, TextModel>();
+
+/**
+ * Editor ids released while their editor was still mounted. Their model is discarded by the
+ * unmount teardown instead of being parked.
+ */
+const RELEASED_EDITOR_IDS = new Set<string>();
+
+/**
+ * Disposes a model, but never one that is still attached to a live editor.
+ * @param model - The model to dispose; no-op when missing, already disposed, or still in use.
+ */
+export function disposeEditorModel(model?: TextModel | null): void {
+  if (!model || model.isDisposed() || model.isAttachedToEditor()) {
+    return;
+  }
+  model.dispose();
+}
+
+/**
+ * Removes and returns the parked model for an editor id, so the caller can attach it to a new editor.
+ * @param id - The editor id, or undefined for anonymous editors which are never cached.
+ * @returns A reusable model, or undefined when there is nothing usable to restore.
+ */
+export function takeCachedEditorModel(id?: string): TextModel | undefined {
+  if (!id) {
+    return undefined;
+  }
+  const model = EDITOR_MODELS_MAP.get(id);
+  EDITOR_MODELS_MAP.delete(id);
+  if (!model || model.isDisposed()) {
+    return undefined;
+  }
+  return model;
+}
+
+/**
+ * Parks a detached model under an editor id, evicting least-recently-used entries past the cap.
+ * @param id - The editor id to park the model under.
+ * @param model - The detached model to keep for a future remount.
+ */
+export function cacheEditorModel(id: string, model: TextModel): void {
+  EDITOR_MODELS_MAP.delete(id);
+  EDITOR_MODELS_MAP.set(id, model);
+
+  for (const [key, cached] of EDITOR_MODELS_MAP) {
+    if (EDITOR_MODELS_MAP.size <= MAX_CACHED_MODELS) {
+      break;
+    }
+    EDITOR_MODELS_MAP.delete(key);
+    disposeEditorModel(cached);
+  }
+}
+
+/**
+ * Whether an editor id was released while its editor was still mounted. Consumes the marker.
+ * @param id - The editor id being torn down.
+ * @returns True when the model must be discarded rather than parked.
+ */
+export function consumeReleasedEditorId(id: string): boolean {
+  return RELEASED_EDITOR_IDS.delete(id);
+}
+
+/**
+ * Discards the model kept for an editor id that will never be shown again, such as a closed query
+ * tab. When that editor is still mounted the model is discarded by its unmount teardown instead.
+ * @param id - The editor id; for query tabs this is the query id.
+ */
+export function releaseEditorModel(id: string): void {
+  const model = EDITOR_MODELS_MAP.get(id);
+  if (model) {
+    EDITOR_MODELS_MAP.delete(id);
+    disposeEditorModel(model);
+    return;
+  }
+  RELEASED_EDITOR_IDS.add(id);
+}
+
+/**
+ * Number of models currently parked for reuse. Exposed for diagnostics and tests.
+ * @returns The parked model count.
+ */
+export function getEditorModelCacheSize(): number {
+  return EDITOR_MODELS_MAP.size;
+}
+
+/** Empties the cache and the released-id markers. Exposed for tests. */
+export function resetEditorModelCache(): void {
+  for (const model of EDITOR_MODELS_MAP.values()) {
+    disposeEditorModel(model);
+  }
+  EDITOR_MODELS_MAP.clear();
+  RELEASED_EDITOR_IDS.clear();
+}

--- a/src/frontend/components/CodeEditorBox/index.spec.tsx
+++ b/src/frontend/components/CodeEditorBox/index.spec.tsx
@@ -204,6 +204,57 @@ describe("CodeEditorBox", () => {
     expect(editorRef.current?.getValue()).toBe("not yet synced");
   });
 
+  test("flushes a pending debounce when the editor unmounts", () => {
+    // switching query tabs unmounts the editor — the in-flight keystrokes must not be dropped
+    const onChange = vi.fn();
+    const { container, unmount } = renderWithTheme(<CodeEditorBox value="" onChange={onChange} debounceMs={300} />);
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "unsaved edit" } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("unsaved edit");
+
+    // the flushed timer must not fire a second time
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not emit on unmount when nothing is pending", () => {
+    const onChange = vi.fn();
+    const { container, unmount } = renderWithTheme(<CodeEditorBox value="" onChange={onChange} debounceMs={50} />);
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "already emitted" } });
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not emit on unmount when blur already flushed the value", () => {
+    const onChange = vi.fn();
+    const { container, unmount } = renderWithTheme(<CodeEditorBox value="" onChange={onChange} debounceMs={300} />);
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "blur wins" } });
+    fireEvent.blur(textarea);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   test("renders placeholder text", () => {
     const { container } = renderWithTheme(<CodeEditorBox placeholder="Enter SQL here" />);
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -122,6 +122,11 @@ export default function CodeEditorBox(props: CodeEditorProps): React.JSX.Element
 
   /** Tracks the last value emitted via onChange to avoid duplicate calls. */
   const lastEmittedRef = useRef<string | undefined>(props.value);
+  /** Latest live-typed value that has not been emitted through onChange yet. */
+  const pendingValueRef = useRef<string | undefined>(undefined);
+  /** Ref to onChange so the unmount flush never runs against a stale closure. */
+  const onChangeRef = useRef(props.onChange);
+  onChangeRef.current = props.onChange;
 
   /** Calls onChange with a debounced delay (used on live typing). */
   const debounceMs = Math.min(props.debounceMs ?? DEFAULT_DEBOUNCE_MS, MAX_DEBOUNCE_MS);
@@ -130,7 +135,10 @@ export default function CodeEditorBox(props: CodeEditorProps): React.JSX.Element
     (newValue: string) => {
       if (!props.onChange) return;
       if (liveChangeTimerRef.current) clearTimeout(liveChangeTimerRef.current);
+      pendingValueRef.current = newValue;
       liveChangeTimerRef.current = setTimeout(() => {
+        liveChangeTimerRef.current = null;
+        pendingValueRef.current = undefined;
         lastEmittedRef.current = newValue;
         props.onChange!(newValue);
       }, debounceMs);
@@ -144,10 +152,29 @@ export default function CodeEditorBox(props: CodeEditorProps): React.JSX.Element
       clearTimeout(liveChangeTimerRef.current);
       liveChangeTimerRef.current = null;
     }
+    pendingValueRef.current = undefined;
     if (!props.onChange || newValue === lastEmittedRef.current) return;
     lastEmittedRef.current = newValue;
     props.onChange(newValue);
   };
+
+  // Flush (never drop) a debounced edit that is still in flight when the editor unmounts, e.g. the
+  // user types and immediately switches query tabs. Without this the last keystrokes are lost.
+  useEffect(
+    () => () => {
+      if (!liveChangeTimerRef.current) return;
+      clearTimeout(liveChangeTimerRef.current);
+      liveChangeTimerRef.current = null;
+
+      const pendingValue = pendingValueRef.current;
+      pendingValueRef.current = undefined;
+      if (pendingValue === undefined || pendingValue === lastEmittedRef.current) return;
+
+      lastEmittedRef.current = pendingValue;
+      onChangeRef.current?.(pendingValue);
+    },
+    [],
+  );
 
   const onSetHeight = (newHeight: string) => {
     setHeightSetting(newHeight);

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -1924,8 +1924,8 @@ export default function MissionControl() {
     document.addEventListener("keydown", onKeyboardShortcutEventForAll, true);
     !appPlatform.isDesktop && document.addEventListener("keydown", onKeyboardShortcutEventForBrowser, true);
     return () => {
-      document.removeEventListener("keydown", onKeyboardShortcutEventForAll);
-      !appPlatform.isDesktop && document.removeEventListener("keydown", onKeyboardShortcutEventForBrowser);
+      document.removeEventListener("keydown", onKeyboardShortcutEventForAll, true);
+      !appPlatform.isDesktop && document.removeEventListener("keydown", onKeyboardShortcutEventForBrowser, true);
     };
   }, []);
 

--- a/src/frontend/components/QueryBoxTabs/index.spec.tsx
+++ b/src/frontend/components/QueryBoxTabs/index.spec.tsx
@@ -26,10 +26,11 @@ vi.mock("src/frontend/components/QueryBox", () => ({
   default: ({ queryId }: any) => <div>QueryBox:{queryId}</div>,
 }));
 vi.mock("src/frontend/components/Tabs", () => ({
-  default: ({ tabHeaders, tabContents }: any) => (
+  default: ({ tabHeaders, tabContents, tabKeys }: any) => (
     <div data-testid="tabs">
       <div>headers:{tabHeaders.length}</div>
       <div>contents:{tabContents.length}</div>
+      <div data-testid="tab-keys">{JSON.stringify(tabKeys)}</div>
     </div>
   ),
 }));
@@ -80,6 +81,21 @@ describe("QueryBoxTabs", () => {
     const { container } = render(<QueryBoxTabs />);
     expect(container.textContent).toContain("headers:3");
     expect(container.textContent).toContain("contents:2");
+  });
+
+  test("passes stable per-query tab keys so tab state cannot stick to the wrong query", () => {
+    // keying tabs by index made DropdownButton `open` state follow the slot, not the query,
+    // after a duplicate/close/reorder
+    useConnectionQueriesMock.mockReturnValue({
+      queries: [
+        { id: "q1", name: "T1", selected: true },
+        { id: "q2", name: "T2" },
+      ],
+      isLoading: false,
+      onSaveQueries: vi.fn(),
+    });
+    const { getByTestId } = render(<QueryBoxTabs />);
+    expect(JSON.parse(getByTestId("tab-keys").textContent || "null")).toEqual(["q1", "q2", "add-query"]);
   });
 
   test("auto-save flip from false to true triggers onSaveQueries", () => {

--- a/src/frontend/components/QueryBoxTabs/index.tsx
+++ b/src/frontend/components/QueryBoxTabs/index.tsx
@@ -127,10 +127,10 @@ export default function QueryBoxTabs() {
 
   const tabIdx = queries?.findIndex((q) => q.selected === true) || 0;
 
-  const tabKeys: string[] = [];
+  const tabKeys: string[] = useMemo(() => [...(queries || []).map((q) => q.id), "add-query"], [queries]);
   const tabHeaders: React.ReactNode[] = useMemo(
     () => [
-      ...(queries || []).map((q, idx) => {
+      ...(queries || []).map((q) => {
         let options = [
           {
             label: "Save",
@@ -215,22 +215,20 @@ export default function QueryBoxTabs() {
           ];
         }
 
-        tabKeys.push(q.name + "." + idx);
-
         return (
-          <>
+          <React.Fragment key={q.id}>
             {q.executing && <CircularProgress size={14} sx={{ mr: 0.5 }} />}
             {q.pinned && <PushPinIcon />}
             {q.name}
             <DropdownButton id="table-action-split-button" options={options}>
               <ArrowDropDownIcon fontSize="small" />
             </DropdownButton>
-          </>
+          </React.Fragment>
         );
       }),
-      <>
+      <React.Fragment key="add-query">
         <AddIcon fontSize="small" aria-label="Add query" /> Add Query
-      </>,
+      </React.Fragment>,
     ],
     [queries],
   );
@@ -259,6 +257,7 @@ export default function QueryBoxTabs() {
       id="QueryBoxTabs"
       tabIdx={tabIdx}
       tabHeaders={tabHeaders}
+      tabKeys={tabKeys}
       tabContents={tabContents}
       orientation={queryTabOrientation}
       onTabChange={(newTabIdx) => {

--- a/src/frontend/hooks/useConnectionQuery.spec.tsx
+++ b/src/frontend/hooks/useConnectionQuery.spec.tsx
@@ -27,6 +27,11 @@ vi.mock("src/frontend/hooks/useFolderItems", () => ({
   useAddRecycleBinItem: () => ({ mutateAsync: vi.fn() }),
 }));
 
+const releaseEditorModelMock = vi.hoisted(() => vi.fn());
+vi.mock("src/frontend/components/CodeEditorBox/editorModelCache", () => ({
+  releaseEditorModel: releaseEditorModelMock,
+}));
+
 vi.mock("src/frontend/hooks/useSetting", () => ({
   useIsQueryTabAutoSaveEnabled: () => mockSettings.isQueryTabAutoSaveEnabled,
   useIsSoftDeleteModeSetting: () => false,
@@ -377,6 +382,33 @@ describe("useConnectionQuery", () => {
       </WrappedContext>,
     );
     await waitFor(() => expect(container.querySelector("[data-testid='count']")?.textContent).toBe("1"));
+  });
+
+  test("onDeleteQueries releases the editor model only for tabs that actually closed", async () => {
+    vi.mocked(SessionStorageConfig.get).mockReturnValue([
+      makeQuery("q1", { selected: true }),
+      makeQuery("q2", { pinned: true }),
+      makeQuery("q3"),
+    ]);
+    function DelConsumer() {
+      const didRef = useRef(false);
+      const { queries, isLoading, onDeleteQueries } = useConnectionQueries();
+      useEffect(() => {
+        if (isLoading || didRef.current) return;
+        didRef.current = true;
+        onDeleteQueries(["q2", "q3"]);
+      }, [isLoading, onDeleteQueries]);
+      return <span data-testid="count">{queries.length}</span>;
+    }
+    const { container } = render(
+      <WrappedContext>
+        <DelConsumer />
+      </WrappedContext>,
+    );
+
+    await waitFor(() => expect(container.querySelector("[data-testid='count']")?.textContent).toBe("2"));
+    // q2 is pinned so it survives the close — its model must stay parked for reuse
+    expect(releaseEditorModelMock.mock.calls.map(([id]) => id)).toEqual(["q3"]);
   });
 
   test("onImportQuery strips timestamps", async () => {

--- a/src/frontend/hooks/useConnectionQuery.tsx
+++ b/src/frontend/hooks/useConnectionQuery.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { releaseEditorModel } from "src/frontend/components/CodeEditorBox/editorModelCache";
 import dataApi from "src/frontend/data/api";
 import { SessionStorageConfig } from "src/frontend/data/config";
 import { getCurrentSessionId } from "src/frontend/data/session";
@@ -346,6 +347,14 @@ export function useConnectionQueries() {
     for (const queryId of queryIds) {
       // make api to delete the query
       dataApi.deleteQuery(queryId);
+    }
+
+    // reclaim the Monaco text model parked for each tab that actually went away (pinned tabs stay).
+    const remainingQueryIds = new Set(_connectionQueries.map((q) => q.id));
+    for (const queryId of queryIds) {
+      if (!remainingQueryIds.has(queryId)) {
+        releaseEditorModel(queryId);
+      }
     }
 
     _invalidateQueries();


### PR DESCRIPTION
## Summary

Monaco editor inside Query Box stops reacting to keypresses after switching between query tabs. Root cause: `AdvancedEditor.tsx` teardown effect had empty `[]` deps, capturing `editor === null` from first render → `editor?.dispose()` always a no-op. Every tab switch leaked a live editor into Monaco's global registry.

### Simplest repro

1. Open app, let query editor render
2. Click Add Query twice → 3 tabs
3. Click between the 3 tabs a few times
4. DevTools: `monaco.editor.getEditors().length`

| Step        | Editors before fix | After fix |
|---|---|---|
| Boot        | 1 | 1 |
| +2 tabs     | 3 (2 detached) | 1 |
| +9 switches | 12 (11 detached) | 1 (0 detached) |

One leaked editor per tab switch, forever. `getModels()` stays at 3 after the fix — one per tab, undo stacks preserved.

### Why keys die

Leaked editor removed from DOM while focused keeps `hasTextFocus() === true` (Chromium fires no blur for a removed node). Being older it wins `getFocusedCodeEditor()`, so Backspace/Enter/arrows/Cmd+A/Cmd+Z route to the invisible zombie. Plain letters still reach the visible widget via `_type`.

### Changes

- **Fix:** create-once/dispose-always lifecycle, explicit TextModel ownership, in-place option updates, bounded LRU cache of detached-only models, pending-edit flush on unmount, model release on tab close, stable `tabKeys`, `removeEventListener` capture flag
- **Tests:** +22 unit + 1 e2e regression test
- **Version:** 3.1.14 → 4.0.0