### PR TITLE
perf: micro-fixes (dead useMemo, memoize provider, cacheTime→gcTime)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -59,20 +59,6 @@ export function DataTableWithJSONList(props: DataTableWithJSONListProps) {
   const tableRenderer = useTableRenderer();
   const isAdvancedTableRenderer = tableRenderer === "advanced";
 
-  useMemo(() => {
-    for (const value of data) {
-      if (value !== null) {
-        for (const columnValue of Object.values(value)) {
-          if (typeof columnValue === "object" && columnValue !== null) {
-            return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  }, [data]);
-
   const columns: ColumnDef<any, any>[] = useMemo(() => {
     const newColumnNames = new Set<string>();
     for (let i = 0; i < data.length; i++) {

--- a/src/frontend/components/VirtualizedConnectionTree/useFlatTreeRows.ts
+++ b/src/frontend/components/VirtualizedConnectionTree/useFlatTreeRows.ts
@@ -154,7 +154,7 @@ export function useFlatTreeRows() {
       queryKey: queryKeys.columns.list(connectionId, databaseId, tableId),
       queryFn: () => dataApi.getConnectionColumns(connectionId, databaseId, tableId),
       staleTime: 5 * 60 * 1000,
-      cacheTime: 10 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
     })),
   });
 

--- a/src/frontend/hooks/useActionDialogs.tsx
+++ b/src/frontend/hooks/useActionDialogs.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 import { AlertInput } from "src/frontend/components/ActionDialogs/AlertDialog";
 import { ChoiceInput, ChoiceOption } from "src/frontend/components/ActionDialogs/ChoiceDialog";
 import { ModalInput } from "src/frontend/components/ActionDialogs/ModalDialog";
@@ -58,7 +58,8 @@ export default function WrappedContext(props: { children: React.ReactNode }): Re
   // State to hold the theme value
   const [data, setData] = useState(_actionDialogs);
   // Provide the theme value and toggle function to the children components
-  return <TargetContext.Provider value={{ data, setData }}>{props.children}</TargetContext.Provider>;
+  const value = useMemo(() => ({ data, setData }), [data]);
+  return <TargetContext.Provider value={value}>{props.children}</TargetContext.Provider>;
 }
 
 /**


### PR DESCRIPTION
### Changes

1. **§1.1** — Delete dead `useMemo` in `DataTable/index.tsx:62-74` whose return value was thrown away. Dropped an O(rows×cols) scan per result set.

2. **§1.3** — Memoize `useActionDialogs` provider value so cascading dialog-consumer re-renders stop.

3. **§1.4** — Rename `cacheTime` → `gcTime` in `useFlatTreeRows.ts:157`. React Query v5 renamed this; column cache was silently using the default 5-minute GC instead of the intended 10 minutes.

### Verification

```bash
npm run lint && npm run typecheck && npm run test-ci
```

No visible behavior change.