### PR TITLE
perf: decodeHtml cell renderer, fix scalar row normalization, stop data mutation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -45,6 +45,14 @@ export const DEFAULT_TABLE_PAGE_SIZE = 50;
 /** Placeholder column name used when a row value is not an object. */
 const UNNAMED_PROPERTY_NAME = "<unnamed_property>";
 
+const _decodeElement = document.createElement("p");
+function decodeHtml(value: unknown): string {
+  const str = String(value);
+  if (!str.includes("&") && !str.includes("<")) return str;
+  _decodeElement.innerHTML = str;
+  return _decodeElement.innerText;
+}
+
 /**
  * A data table that auto-generates columns from a JSON array.
  * Dynamically infers column definitions from the data keys and renders values
@@ -59,19 +67,19 @@ export function DataTableWithJSONList(props: DataTableWithJSONListProps) {
   const tableRenderer = useTableRenderer();
   const isAdvancedTableRenderer = tableRenderer === "advanced";
 
-  const columns: ColumnDef<any, any>[] = useMemo(() => {
+  const { columns, tableData } = useMemo(() => {
     const newColumnNames = new Set<string>();
+    const normalizedData = [];
     for (let i = 0; i < data.length; i++) {
       const row = data[i];
       if (typeof row === "object" && row !== null) {
-        // is an object, then render as a list of properties
+        normalizedData[i] = row;
         for (const header of Object.keys(row)) {
           newColumnNames.add(header);
         }
       } else {
-        // otherwise, render it as a column named `unknown`
+        normalizedData[i] = { [UNNAMED_PROPERTY_NAME]: row };
         newColumnNames.add(UNNAMED_PROPERTY_NAME);
-        data[i] = { UNNAMED_PROPERTY_NAME: row };
       }
     }
 
@@ -82,86 +90,85 @@ export function DataTableWithJSONList(props: DataTableWithJSONListProps) {
       cell: (info: any) => <span style={{ fontFamily: "monospace", opacity: 0.5 }}>{info.row.index + 1}</span>,
     };
 
-    return [
-      rowNumberColumn,
-      ...[...newColumnNames].map((columnName) => {
-        return {
-          header: columnName,
-          enableSorting: true,
-          enableColumnFilter: !!props.enableColumnFilter,
-          accessorFn: (data: any) => {
-            let columnValue = data[columnName];
-            if (columnValue === null) {
-              columnValue = "null";
-            } else if (columnValue === undefined) {
-              columnValue = "undefined";
-            } else if (columnValue === true) {
-              columnValue = "true";
-            } else if (columnValue === false) {
-              columnValue = "false";
-            } else if (typeof columnValue === "object") {
-              columnValue = JSON.stringify(columnValue);
-            }
+    return {
+      columns: [
+        rowNumberColumn,
+        ...[...newColumnNames].map((columnName) => {
+          return {
+            header: columnName,
+            enableSorting: true,
+            enableColumnFilter: !!props.enableColumnFilter,
+            accessorFn: (rowData: any) => {
+              let columnValue = rowData[columnName];
+              if (columnValue === null) {
+                columnValue = "null";
+              } else if (columnValue === undefined) {
+                columnValue = "undefined";
+              } else if (columnValue === true) {
+                columnValue = "true";
+              } else if (columnValue === false) {
+                columnValue = "false";
+              } else if (typeof columnValue === "object") {
+                columnValue = JSON.stringify(columnValue);
+              }
 
-            const html = document.createElement("p");
-            html.innerHTML = columnValue;
-            return html.innerText;
-          },
-          cell: (info: any) => {
-            const columnValue = info.row.original[columnName];
-            if (columnValue === null) {
-              return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="info" label="null" />;
-            } else if (columnValue === undefined) {
-              return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="default" label="undefined" />;
-            } else if (columnValue === true || columnValue?.toString()?.toLowerCase() === "true") {
-              return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="success" label="true" />;
-            } else if (columnValue === false || columnValue?.toString()?.toLowerCase() === "false") {
-              return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="error" label="false" />;
-            } else if (typeof columnValue === "number") {
-              return <span style={{ fontFamily: "monospace" }}>{columnValue}</span>;
-            } else if (typeof columnValue === "object") {
+              return decodeHtml(columnValue);
+            },
+            cell: (info: any) => {
+              const columnValue = info.row.original[columnName];
+              if (columnValue === null) {
+                return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="info" label="null" />;
+              } else if (columnValue === undefined) {
+                return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="default" label="undefined" />;
+              } else if (columnValue === true || columnValue?.toString()?.toLowerCase() === "true") {
+                return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="success" label="true" />;
+              } else if (columnValue === false || columnValue?.toString()?.toLowerCase() === "false") {
+                return <Chip sx={{ textTransform: "uppercase", fontStyle: "italic" }} size="small" color="error" label="false" />;
+              } else if (typeof columnValue === "number") {
+                return <span style={{ fontFamily: "monospace" }}>{columnValue}</span>;
+              } else if (typeof columnValue === "object") {
+                return (
+                  <span
+                    style={{
+                      width: "100%",
+                      display: "inline-block",
+                      fontFamily: "monospace",
+                      overflow: "hidden",
+                      whiteSpace: "nowrap",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {JSON.stringify(columnValue)}
+                  </span>
+                );
+              }
               return (
                 <span
                   style={{
-                    width: "100%",
-                    display: "inline-block",
-                    fontFamily: "monospace",
+                    display: "block",
                     overflow: "hidden",
-                    whiteSpace: "nowrap",
                     textOverflow: "ellipsis",
+                    wordBreak: "break-all",
+                    whiteSpace: "nowrap",
+                    maxWidth: "fit-content",
                   }}
                 >
-                  {JSON.stringify(columnValue)}
+                  {columnValue || ""}
                 </span>
               );
-            }
-            return (
-              <span
-                style={{
-                  display: "block",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  wordBreak: "break-all",
-                  whiteSpace: "nowrap",
-                  maxWidth: "fit-content",
-                }}
-              >
-                {columnValue || ""}
-              </span>
-            );
-          },
-        };
-      }),
-    ];
+            },
+          };
+        }),
+      ],
+      tableData: normalizedData,
+    };
   }, [data]);
 
   if (isAdvancedTableRenderer) {
-    // use the modern table
-    return <ModernDataTable {...props} columns={columns} />;
+    return <ModernDataTable {...props} data={tableData} columns={columns} />;
   }
 
-  // always use legacy table for now
-  return <LegacyDataTable {...props} columns={columns} />;
+  return <LegacyDataTable {...props} data={tableData} columns={columns} />;
 }
 
 export default LegacyDataTable;


### PR DESCRIPTION
### Changes

1. **§1.2** — Replace per-cell DOM node construction (`createElement`+`innerHTML`+`innerText`) with a reuseable `decodeHtml` function. Skips HTML parsing entirely for values without `&` or `<`. Fix: short-circuit returns early on numeric values via `String()` coercion.

2. **§4.1** — Fix computed property key: `{ UNNAMED_PROPERTY_NAME: row }` created key `"UNNAMED_PROPERTY_NAME"` instead of `"<unnamed_property>"`. Result: scalar rows (Redis lists, raw values) now render in the correct column instead of a blank one.

3. **§4.2** — Build normalized data copy inside `useMemo` instead of mutating `props.data[i]` during render. Unsafe under React 19 concurrent rendering.

### Verification

```bash
npm run lint && npm run typecheck && npm run test-ci
```

All coupled in the same `useMemo` block — one atomic change.