### PR TITLE
perf: clean stale build/assets/ in prebuild to prevent bundle bloat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -58,6 +58,14 @@ fs.mkdirSync("public", { recursive: true });
 cpSync("package.json", "src/package.json");
 
 const rootPkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
+
+// Clean stale assets from previous builds — prevents unbounded bundle bloat
+// in portal and sidecar embeds (scripts/vite-plugin-embed-frontend.ts walks build/ recursively).
+const assetsDir = "build/assets";
+if (fs.existsSync(assetsDir)) {
+  fs.rmSync(assetsDir, { recursive: true });
+  log(`Cleaned: ${assetsDir}`);
+}
 const buildPkg = {
   name: rootPkg.name,
   version: rootPkg.version,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "4.0.0",
+  "version": "4.3.0",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",
@@ -21,13 +21,26 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* https://api.github.com https://github.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:",
-      "dangerousDisableAssetCspModification": ["style-src"]
+      "dangerousDisableAssetCspModification": [
+        "style-src"
+      ]
     }
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis", "deb", "appimage"],
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+    "targets": [
+      "dmg",
+      "nsis",
+      "deb",
+      "appimage"
+    ],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "resources": {
       "resources/": "resources/"
     }


### PR DESCRIPTION
### Changes

**§1.7** — Clean `build/assets/` in `scripts/prebuild.js` before each build. `emptyOutDir: false` in Vite config causes stale hashed assets to accumulate forever. The embed plugin (`scripts/vite-plugin-embed-frontend.ts`) walks `build/` recursively — stale chunks get base64-encoded into portal and sidecar bundles.

### Verification

```bash
npm run lint && npm run typecheck && npm run test-ci
```

**Must precede any bundle measurement** (PR 4).