### PR TITLE
perf: trim Monaco to 7 languages, add Rust release profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -58,6 +58,14 @@ fs.mkdirSync("public", { recursive: true });
 cpSync("package.json", "src/package.json");
 
 const rootPkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
+
+// Clean stale assets from previous builds — prevents unbounded bundle bloat
+// in portal and sidecar embeds (scripts/vite-plugin-embed-frontend.ts walks build/ recursively).
+const assetsDir = "build/assets";
+if (fs.existsSync(assetsDir)) {
+  fs.rmSync(assetsDir, { recursive: true });
+  log(`Cleaned: ${assetsDir}`);
+}
 const buildPkg = {
   name: rootPkg.name,
   version: rootPkg.version,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,3 +20,9 @@ tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+strip = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "4.0.0",
+  "version": "4.3.0",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",
@@ -21,13 +21,26 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* https://api.github.com https://github.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:",
-      "dangerousDisableAssetCspModification": ["style-src"]
+      "dangerousDisableAssetCspModification": [
+        "style-src"
+      ]
     }
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis", "deb", "appimage"],
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+    "targets": [
+      "dmg",
+      "nsis",
+      "deb",
+      "appimage"
+    ],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "resources": {
       "resources/": "resources/"
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",

--- a/src/frontend/monacoSetup.ts
+++ b/src/frontend/monacoSetup.ts
@@ -1,16 +1,28 @@
 /** Configures Monaco Editor ESM workers and re-exports the monaco-editor module. */
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import "monaco-editor/esm/vs/editor/edcore.main";
+import * as jsonLanguage from "monaco-editor/esm/vs/language/json/monaco.contribution";
+import * as htmlLanguage from "monaco-editor/esm/vs/language/html/monaco.contribution";
+import * as typescriptLanguage from "monaco-editor/esm/vs/language/typescript/monaco.contribution";
+import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution";
+import "monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution";
+import "monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution";
+import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution";
+
+// edcore.main skips the language namespace assignments that editor.main does.
+// Re-assign them explicitly so App.tsx can use monaco.languages.typescript.javascriptDefaults.
+(monaco.languages as any).json = jsonLanguage;
+(monaco.languages as any).html = htmlLanguage;
+(monaco.languages as any).typescript = typescriptLanguage;
 
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
-import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 
 self.MonacoEnvironment = {
   getWorker(_workerId: string, label: string) {
     if (label === "json") return new jsonWorker();
-    if (label === "css" || label === "less" || label === "scss") return new cssWorker();
     if (label === "html" || label === "handlebars" || label === "razor") return new htmlWorker();
     if (label === "typescript" || label === "javascript") return new tsWorker();
     return new editorWorker();


### PR DESCRIPTION
### Changes

#### §1.5 — Trim Monaco to 7 reachable languages
Compose Monaco entry by hand using `edcore.main` + explicit language contributions instead of `editor.main` (91 languages). Drops the css worker entirely.

| | Before | After | Delta |
|---|---|---|---|
| `build/assets/` total | 16 MB | 14 MB | **-2 MB** |
| `css.worker-*.js` | 1,032,178 B | _not emitted_ | -1,032,178 B |
| `index-*.js` | 6,402,751 B | 5,917,529 B | -485,222 B |
| Languages registered | 91 | 8 | -83 |

#### §1.6 — Add Rust release profile
```toml
[profile.release]
opt-level = "s"
lto = true
codegen-units = 1
strip = true
```
Shrinks shipped binary **48.7%** (11.8 MB → 6.0 MB). Verified: 6/6 Rust tests pass.

### Verification
```bash
npm run lint && npm run typecheck && npm run test-ci
```