### PR TITLE
fix: restore missing Monaco grammars, fix normalizedData type error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlui-native",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlui-native",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/.schema/config.schema.json",
   "productName": "sqlui-native",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "identifier": "io.synle.github.sqlui-native",
   "build": {
     "frontendDist": "../build",
@@ -21,13 +21,26 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* https://api.github.com https://github.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:",
-      "dangerousDisableAssetCspModification": ["style-src"]
+      "dangerousDisableAssetCspModification": [
+        "style-src"
+      ]
     }
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis", "deb", "appimage"],
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+    "targets": [
+      "dmg",
+      "nsis",
+      "deb",
+      "appimage"
+    ],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "resources": {
       "resources/": "resources/"
     }

--- a/src/frontend/components/DataTable/index.tsx
+++ b/src/frontend/components/DataTable/index.tsx
@@ -69,7 +69,7 @@ export function DataTableWithJSONList(props: DataTableWithJSONListProps) {
 
   const { columns, tableData } = useMemo(() => {
     const newColumnNames = new Set<string>();
-    const normalizedData = [];
+    const normalizedData: any[] = [];
     for (let i = 0; i < data.length; i++) {
       const row = data[i];
       if (typeof row === "object" && row !== null) {

--- a/src/frontend/monacoSetup.spec.ts
+++ b/src/frontend/monacoSetup.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vitest";
+import { monaco } from "src/frontend/monacoSetup";
+
+/**
+ * Languages that must be registered because frontend code reaches them.
+ *
+ * Derivation (update when adding a dialect or language mode):
+ * - adapters' getSyntaxMode() returns: sql, javascript, graphql, shell
+ * - SqluiCore.LanguageMode: javascript, python, java
+ * - REST response sniffing (RestApiResultBox): json, html, text
+ * - embedded <style> in html responses needs: css
+ * - javascript basic grammar extends: typescript
+ */
+const REQUIRED_LANGUAGES = new Set([
+  "sql",
+  "javascript",
+  "graphql",
+  "shell",
+  "json",
+  "html",
+  "python",
+  "java",
+  "css",
+  "typescript",
+  "text",
+]);
+
+describe("monacoSetup", () => {
+  test("all required languages are registered", () => {
+    const registered = monaco.languages.getLanguages();
+    const registeredIds = registered.map((l) => l.id);
+    const missing = [...REQUIRED_LANGUAGES].filter((id) => !registeredIds.includes(id));
+    expect(missing).toEqual([]);
+  });
+
+  test("html language service is registered (for App.tsx monaco.languages.html)", () => {
+    expect((monaco.languages as any).html).toBeDefined();
+    expect((monaco.languages as any).html.htmlDefaults).toBeDefined();
+  });
+
+  test("typescript language service is registered (for App.tsx monaco.languages.typescript)", () => {
+    expect((monaco.languages as any).typescript).toBeDefined();
+    expect((monaco.languages as any).typescript.javascriptDefaults).toBeDefined();
+  });
+
+  test("json language service is registered (for App.tsx monaco.languages.json)", () => {
+    expect((monaco.languages as any).json).toBeDefined();
+    expect((monaco.languages as any).json.jsonDefaults).toBeDefined();
+  });
+});

--- a/src/frontend/monacoSetup.ts
+++ b/src/frontend/monacoSetup.ts
@@ -15,6 +15,12 @@ import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution";
 (monaco.languages as any).html = htmlLanguage;
 (monaco.languages as any).typescript = typescriptLanguage;
 
+import "monaco-editor/esm/vs/basic-languages/html/html.contribution";
+import "monaco-editor/esm/vs/basic-languages/css/css.contribution";
+import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
+import "monaco-editor/esm/vs/basic-languages/java/java.contribution";
+import "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution";
+
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";


### PR DESCRIPTION
### Regression fixes from PRs #10–#14

#### §9.1 — Missing Monaco grammars
PR #13 over-trimmed the Monaco entry. Added basic-language imports for:
- **html** — html REST responses had no tokenization
- **css** — embedded `<style>` blocks inside HTML lost tokenization
- **python** — rendered code snippets (`SqluiCore.LanguageMode`)
- **java** — same
- **typescript** — javascript grammar depends on it

Size win preserved (-2 MB). Now 11 languages registered vs 6.

#### §9.2 — Typecheck error
`const normalizedData = []` inferred `never[]` under strict mode. Fixed with `: any[]` annotation.

#### Test coverage
Added `monacoSetup.spec.ts` that bakes in the required language set derived from adapters' `getSyntaxMode()`, `SqluiCore.LanguageMode`, REST sniffing, and embedded CSS — prevents silent drift.

### Verification
```bash
npm run lint && npm run typecheck && npm run test-ci
```