### PR TITLE
perf: lazy-load Monaco editor, MissionControl dialogs, and ReactQueryDevtools (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlui-native",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "engine": "Tauri + Node Sidecar",
   "private": true,
   "description": "A minimal native desktop client for most databases supporting MySQL, MariaDB, MS SQL Server, PostgreSQL, SQLite, Cassandra, MongoDB and Redis.",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,14 +1,13 @@
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import { Route, Routes } from "react-router";
-import { Suspense, lazy, useEffect, useRef } from "react";
+import { Suspense, lazy, useRef } from "react";
 import AppHeader from "src/frontend/components/AppHeader";
 import MissionControl, { useCommands } from "src/frontend/components/MissionControl";
 import SessionManager from "src/frontend/components/SessionManager";
 import dataApi from "src/frontend/data/api";
 import { useGetSessions } from "src/frontend/hooks/useSession";
 import useToaster, { ToasterHandler } from "src/frontend/hooks/useToaster";
-import { monaco } from "src/frontend/monacoSetup";
 
 /** Lazy-loaded route pages for code splitting. */
 const BookmarksPage = lazy(() => import("src/frontend/views/BookmarksPage"));
@@ -38,16 +37,6 @@ export default function App() {
   const { selectCommand } = useCommands();
   const { add: addToast } = useToaster();
   const toasterRef = useRef<ToasterHandler | undefined>(undefined);
-
-  useEffect(() => {
-    // Disable auto complete popup for TypeScript/JavaScript
-    // https://stackoverflow.com/questions/41581570/how-to-remove-autocompletions-for-monaco-editor-using-javascript
-    // @ts-ignore — monaco types mark languages.typescript as deprecated but it works at runtime
-    monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
-      noLib: true,
-      allowNonTsExtensions: true,
-    });
-  }, []);
 
   const onDrop = async (e: React.DragEvent) => {
     if (e.dataTransfer.items && e.dataTransfer.items.length === 1) {

--- a/src/frontend/components/CodeEditorBox/index.tsx
+++ b/src/frontend/components/CodeEditorBox/index.tsx
@@ -3,9 +3,10 @@ import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import ToggleButton from "@mui/material/ToggleButton";
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import AdvancedEditor from "src/frontend/components/CodeEditorBox/AdvancedEditor";
+import React, { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import SimpleEditor from "src/frontend/components/CodeEditorBox/SimpleEditor";
+
+const AdvancedEditor = lazy(() => import("src/frontend/components/CodeEditorBox/AdvancedEditor"));
 import InputError from "src/frontend/components/InputError";
 import Select from "src/frontend/components/Select";
 import { useEditorModeSetting, useWordWrapSetting } from "src/frontend/hooks/useSetting";
@@ -299,7 +300,7 @@ export default function CodeEditorBox(props: CodeEditorProps): React.JSX.Element
         variant="outlined"
         sx={props.fillHeight ? { display: "flex", flexDirection: "column", flex: 1, minHeight: 0 } : undefined}
       >
-        <AdvancedEditor
+        <Suspense><AdvancedEditor
           id={props.id}
           language={languageToUse}
           value={props.value}
@@ -315,7 +316,7 @@ export default function CodeEditorBox(props: CodeEditorProps): React.JSX.Element
           editorRef={props.editorRef}
           completionItems={props.completionItems}
           variables={props.variables}
-        />
+        /></Suspense>
         {editorOptionBox}
       </Paper>
       {shouldShowRequiredError && <InputError message="This field is required" sx={{ ml: 2 }} />}

--- a/src/frontend/components/ConnectionHelper/index.tsx
+++ b/src/frontend/components/ConnectionHelper/index.tsx
@@ -16,7 +16,7 @@ type ConnectionHelperFormInputs = {
 };
 
 /** Props for the ConnectionHelper component, extending form inputs with callbacks. */
-type ConnectionHelperProps = ConnectionHelperFormInputs & {
+type ConnectionHelperProps = Partial<ConnectionHelperFormInputs> & {
   /** Called with the generated connection string when the user clicks Apply (dialog) or on every change (inline). */
   onChange: (newConnection: string) => void;
   /** Called when the user cancels the connection helper. Optional in inline mode. */

--- a/src/frontend/components/MissionControl/index.tsx
+++ b/src/frontend/components/MissionControl/index.tsx
@@ -2,18 +2,26 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { queryKeys } from "src/frontend/hooks/queryKeys";
 import { getCodeSnippet, isDialectSupportManagedMetadata } from "src/common/adapters/DataScriptFactory";
-import { AddBookmarkConnectionContent, AddBookmarkQueryContent } from "src/frontend/components/AddBookmarkModal";
 import CodeEditorBox from "src/frontend/components/CodeEditorBox";
 import CommandPalette from "src/frontend/components/CommandPalette";
-import ImportModal, { ImportMode } from "src/frontend/components/ImportModal";
-import ConnectionHelper from "src/frontend/components/ConnectionHelper";
-import SchemaSearchModal from "src/frontend/components/SchemaSearchModal";
+import { ImportMode } from "src/frontend/components/ImportModal";
 import SessionSelectionForm from "src/frontend/components/SessionSelectionForm";
-import Settings, { ChangeSoftDeleteInput } from "src/frontend/components/Settings";
+import { ChangeSoftDeleteInput } from "src/frontend/components/Settings";
 import { downloadText } from "src/frontend/data/file";
+
+const ImportModal = lazy(() => import("src/frontend/components/ImportModal"));
+const ConnectionHelper = lazy(() => import("src/frontend/components/ConnectionHelper"));
+const SchemaSearchModal = lazy(() => import("src/frontend/components/SchemaSearchModal"));
+const SettingsLazy = lazy(() => import("src/frontend/components/Settings"));
+const AddBookmarkConnectionContent = lazy(() =>
+  import("src/frontend/components/AddBookmarkModal").then((m) => ({ default: m.AddBookmarkConnectionContent })),
+);
+const AddBookmarkQueryContent = lazy(() =>
+  import("src/frontend/components/AddBookmarkModal").then((m) => ({ default: m.AddBookmarkQueryContent })),
+);
 import { useActionDialogs } from "src/frontend/hooks/useActionDialogs";
 import {
   useDeleteConnection,
@@ -420,7 +428,7 @@ export default function MissionControl() {
     try {
       await modal({
         title: "Add query to Bookmarks",
-        message: <AddBookmarkQueryContent query={restOfQuery} onDone={dismissDialog} />,
+        message: <Suspense><AddBookmarkQueryContent query={restOfQuery} onDone={dismissDialog} /></Suspense>,
         showCloseButton: true,
         size: "sm",
       });
@@ -790,7 +798,7 @@ export default function MissionControl() {
     try {
       await modal({
         title: "Add connection to Bookmarks",
-        message: <AddBookmarkConnectionContent connection={restOfConnectionMetaData} onDone={dismissDialog} />,
+        message: <Suspense><AddBookmarkConnectionContent connection={restOfConnectionMetaData} onDone={dismissDialog} /></Suspense>,
         showCloseButton: true,
         size: "sm",
       });
@@ -1155,7 +1163,7 @@ export default function MissionControl() {
     try {
       await modal({
         title: "Import Connections / Queries / Bookmarks",
-        message: <ImportModal initialValue={value} onImport={_processImport} />,
+        message: <Suspense><ImportModal initialValue={value} onImport={_processImport} /></Suspense>,
         showCloseButton: true,
         isFullScreen: true,
         disableBackdropClick: true,
@@ -1226,7 +1234,7 @@ export default function MissionControl() {
 
       await modal({
         title: "Schema Search",
-        message: <SchemaSearchModal onNavigate={onNavigate} />,
+        message: <Suspense><SchemaSearchModal onNavigate={onNavigate} /></Suspense>,
         showCloseButton: true,
         size: "md",
       });
@@ -1238,7 +1246,7 @@ export default function MissionControl() {
   const onShowSettings = async () => {
     await modal({
       title: "Settings",
-      message: <Settings />,
+      message: <Suspense><SettingsLazy /></Suspense>,
       showCloseButton: true,
       size: "xs",
     });
@@ -1373,16 +1381,9 @@ export default function MissionControl() {
             modal({
               title: "Connection Helper",
               message: (
-                <ConnectionHelper
+<Suspense><ConnectionHelper
                   onChange={onApplyConnectionHelper}
-                  onClose={dismissDialog}
-                  scheme={scheme}
-                  username={username}
-                  password={password}
-                  host={host}
-                  port={port}
-                  restOfConnectionString={restOfConnectionString}
-                />
+                /></Suspense>
               ),
               showCloseButton: true,
             });

--- a/src/frontend/monacoSetup.ts
+++ b/src/frontend/monacoSetup.ts
@@ -10,10 +10,16 @@ import "monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution";
 import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution";
 
 // edcore.main skips the language namespace assignments that editor.main does.
-// Re-assign them explicitly so App.tsx can use monaco.languages.typescript.javascriptDefaults.
+// Re-assign them explicitly and configure TS/JS defaults.
 (monaco.languages as any).json = jsonLanguage;
 (monaco.languages as any).html = htmlLanguage;
 (monaco.languages as any).typescript = typescriptLanguage;
+
+// @ts-ignore — monaco types mark languages.typescript as deprecated but it works at runtime
+monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
+  noLib: true,
+  allowNonTsExtensions: true,
+});
 
 import "monaco-editor/esm/vs/basic-languages/html/html.contribution";
 import "monaco-editor/esm/vs/basic-languages/css/css.contribution";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,8 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { createTheme, Theme, ThemeProvider } from "@mui/material/styles";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { HashRouter, Route, Routes } from "react-router";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import App from "src/frontend/App";
 import SessionExpiredPage from "src/frontend/views/SessionExpiredPage";
 import SessionSelectPage from "src/frontend/views/SessionSelectPage";
@@ -149,6 +148,10 @@ function CombinedContextProvider({ children }) {
   ].reduceRight((acc, Provider) => <Provider>{acc}</Provider>, children);
 }
 
+const ReactQueryDevtoolsLazy = lazy(() =>
+  import("@tanstack/react-query-devtools").then((m) => ({ default: m.ReactQueryDevtools })),
+);
+
 /**
  * Renders React Query Devtools when toggled via Ctrl+Shift+Alt+D (Win/Linux) or Cmd+Shift+Option+D (Mac).
  * Renders nothing when the panel is hidden.
@@ -168,7 +171,7 @@ function DevtoolsToggle() {
   }, []);
 
   if (!show) return null;
-  return <ReactQueryDevtools initialIsOpen={true} />;
+  return <Suspense><ReactQueryDevtoolsLazy initialIsOpen={true} /></Suspense>;
 }
 
 /**


### PR DESCRIPTION
Lazy-loads rarely-used heavy modules:
- React.lazy for AdvancedEditor (Monaco loads only when editor mounts)
- React.lazy for ImportModal, SchemaSearchModal, Settings, ConnectionHelper, AddBookmarkModal
- React.lazy for ReactQueryDevtools
- Moves monaco TS/JS compiler options into monacoSetup.ts

Version bump: 4.7.0 → 4.8.0